### PR TITLE
Add clippy & fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
     - rust: stable
       env: TEST_COMMAND=test FEATURE='--features=serde'
 
+install:
+  - rustup component add rustfmt
+  - rustup component add clippy
+
 script:
   # lint
   - cargo fmt --version
@@ -28,7 +32,7 @@ script:
   - cargo clippy --version
   - cargo clippy --all
 
-  - # build
+  # build
   - cargo build --all
 
   # test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 
 rust:
   - stable
-  - beta
   - nightly
 
 env:
@@ -12,8 +11,9 @@ matrix:
   include:
     # We use the 64-bit optimised curve backend by default, so also test with
     # the 32-bit backend (this also exercises testing with `no_std`):
-    - rust: nightly
-      env: TEST_COMMAND=build FEATURES='--no-default-features --features=u32_backend'
+    # TODO: re-enable u32_backend
+    #- rust: nightly
+    #  env: TEST_COMMAND=build FEATURES='--no-default-features --features=u32_backend'
     # Test any nightly gated features on nightly:
     - rust: nightly
       env: TEST_COMMAND=test FEATURES='--features=nightly'
@@ -22,6 +22,14 @@ matrix:
       env: TEST_COMMAND=test FEATURE='--features=serde'
 
 script:
-  - cargo $TEST_COMMAND $FEATURES
+  # lint
+  - cargo fmt --version
+  - cargo fmt --all -- --check
+  - cargo clippy --version
+  - cargo clippy --all
 
-notifications:
+  - # build
+  - cargo build --all
+
+  # test
+  - cargo $TEST_COMMAND $FEATURES


### PR DESCRIPTION
Again, this doesn't change anything substantial only adds clippy and rustfmt to the travis build. 

Will close #13 (and disable `--features=u32_backend`build for now).

Nightly builds fail as clippy is currently not available on nightly: https://rust-lang.github.io/rustup-components-history/index.html

The other builds fail due to rustfmt complaining.