### PR TITLE
Bypass rand_hack to build for no_std

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -86,8 +86,14 @@ pub trait SigningTranscript {
     /// Produce a secret witness scalar `k`, aka nonce, from the protocol
     /// transcript and any "nonce seeds" kept with the secret keys.
     fn witness_scalar(&self, label: &'static [u8], nonce_seeds: &[&[u8]]) -> Scalar {
+        self.witness_scalar_rng(label, nonce_seeds, super::rand_hack())
+    }
+
+    /// Produce a secret witness scalar `k`, aka nonce, from the protocol
+    /// transcript and any "nonce seeds" kept with the secret keys, while passing an rng.
+    fn witness_scalar_rng<R: RngCore+CryptoRng>(&self, label: &'static [u8], nonce_seeds: &[&[u8]], rng: R) -> Scalar {
         let mut scalar_bytes = [0u8; 64];
-        self.witness_bytes(label, &mut scalar_bytes, nonce_seeds);
+        self.witness_bytes_rng(label, &mut scalar_bytes, nonce_seeds, rng);
         Scalar::from_bytes_mod_order_wide(&scalar_bytes)
     }
 


### PR DESCRIPTION
### Motivation
I am using schnorrkel signatures in a no_std environment, however the rand_hack requirement for signing via witness_scalar was causing collisions via rand_core. This PR introduces bypasses to calls to rand_hack and allows the caller to provide an rng. For example, with `default-features = false`, the following builds and runs in the no_std environment of SGX:

```rust
let sig: Signature =
                keypair.sign_rng(ctx.bytes(&fingerprint), &mut csprng);
```

This approach may also address related no_std issue #31.

### In this PR
* Adds `witness_scalar_rng` to SigningTranscript
* Adds `sign_rng` to SecretKey
* Modifies non-rng methods to call the _rng method with `super::rand_hack()`