### PR TITLE
Use `serde_bytes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ version = "0.11.5"
 default-features = false
 optional = true
 
+[dependencies.cfg-if]
+version = "1.0.0"
+optional = true
+
 [dependencies.sha2]
 version = "0.9.3"
 default-features = false
@@ -107,13 +111,13 @@ harness = false
 default = ["std", "u64_backend", "getrandom"] # "rand"
 preaudit_deprecated = []
 nightly = ["curve25519-dalek/nightly", "rand/nightly"] # "zeroize/nightly"
-alloc = ["curve25519-dalek/alloc", "rand_core/alloc"]
-std = ["getrandom", "curve25519-dalek/std"] # "failure/std"
+alloc = ["curve25519-dalek/alloc", "rand_core/alloc", "serde_bytes/alloc"]
+std = ["getrandom", "curve25519-dalek/std", "serde_bytes/std"] # "failure/std"
 asm = ["sha2/asm"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
-serde = ["serde_crate", "serde_bytes"]
+serde = ["serde_crate", "serde_bytes", "cfg-if"]
 # We cannot make getrandom a direct dependency because rand_core makes
 # getrandom a feature name, which requires forwarding.
 getrandom = ["rand_core/getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,14 @@ version = "0.3"
 default-features = false
 optional = true
 
-[dependencies.serde]
+[dependencies.serde_crate]
 version = "1.0.123"
+package = "serde"
+default-features = false
+optional = true
+
+[dependencies.serde_bytes]
+version = "0.11.5"
 default-features = false
 optional = true
 
@@ -106,7 +112,7 @@ asm = ["sha2/asm"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
-
+serde = ["serde_crate", "serde_bytes"]
 # We cannot make getrandom a direct dependency because rand_core makes
 # getrandom a feature name, which requires forwarding.
 getrandom = ["rand_core/getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ sha2 = "0.9.3"
 sha3 = "0.9.1"
 bincode = "1.3.2"
 criterion = "0.3.4"
+serde_json = "1.0.64"
 
 [[bench]]
 name = "schnorr_benchmarks"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -160,7 +160,7 @@ impl ::failure::Fail for SignatureError {}
 /// `impl From<SignatureError> for E where E: ::serde::de::Error`.
 #[cfg(feature = "serde")]
 pub fn serde_error_from_signature_error<E>(err: SignatureError) -> E
-where E: ::serde::de::Error
+where E: ::serde_crate::de::Error
 {
     use self::SignatureError::*;
     match err {

--- a/src/serdey.rs
+++ b/src/serdey.rs
@@ -31,8 +31,10 @@ impl ::serde_crate::Serialize for $t {
 impl<'d> ::serde_crate::Deserialize<'d> for $t {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::serde_crate::Deserializer<'d> {
         cfg_if::cfg_if!{
-            if #[cfg(any(feature = "alloc", feature = "std"))] {
-                let bytes = <::serde_bytes::ByteBuf>::deserialize(deserializer)?;
+            if #[cfg(feature = "std")] {
+                let bytes = <std::borrow::Cow<'_, [u8]>>::deserialize(deserializer)?;
+            } else if #[cfg(feature = "alloc")] {
+                let bytes = <alloc::borrow::Cow<'_, [u8]>>::deserialize(deserializer)?;
             } else {
                 let bytes = <&::serde_bytes::Bytes>::deserialize(deserializer)?;
             }

--- a/src/serdey.rs
+++ b/src/serdey.rs
@@ -30,7 +30,13 @@ impl ::serde_crate::Serialize for $t {
 
 impl<'d> ::serde_crate::Deserialize<'d> for $t {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::serde_crate::Deserializer<'d> {
-        let bytes = <&::serde_bytes::Bytes>::deserialize(deserializer)?;
+        cfg_if::cfg_if!{
+            if #[cfg(any(feature = "alloc", feature = "std"))] {
+                let bytes = <::serde_bytes::ByteBuf>::deserialize(deserializer)?;
+            } else {
+                let bytes = <&::serde_bytes::Bytes>::deserialize(deserializer)?;
+            }
+        }
 
         Self::from_bytes(bytes.as_ref())
                 .map_err(crate::errors::serde_error_from_signature_error)

--- a/src/serdey.rs
+++ b/src/serdey.rs
@@ -46,6 +46,7 @@ mod test {
     use std::vec::Vec;
 
     use bincode::{serialize, serialized_size, deserialize};
+    use serde_json::{to_value, from_value, to_string, from_str};
 
     use curve25519_dalek::ristretto::{CompressedRistretto};
 
@@ -93,10 +94,39 @@ mod test {
     }
 
     #[test]
+    fn serialize_deserialize_signature_json() {
+        let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+
+        let encoded_signature = to_value(&signature).unwrap();
+        let decoded_signature: Signature = from_value(encoded_signature).unwrap();
+
+        assert_eq!(signature, decoded_signature);
+
+        let encoded_signature = to_string(&signature).unwrap();
+        let decoded_signature: Signature = from_str(&encoded_signature).unwrap();
+
+        assert_eq!(signature, decoded_signature);
+    }
+
+    #[test]
     fn serialize_deserialize_public_key() {
         let public_key = PublicKey::from_compressed(COMPRESSED_PUBLIC_KEY).unwrap();
         let encoded_public_key: Vec<u8> = serialize(&public_key).unwrap();
         let decoded_public_key: PublicKey = deserialize(&encoded_public_key).unwrap();
+
+        assert_eq!(public_key, decoded_public_key);
+    }
+
+    #[test]
+    fn serialize_deserialize_public_key_json() {
+        let public_key = PublicKey::from_compressed(COMPRESSED_PUBLIC_KEY).unwrap();
+        let encoded_public_key = to_value(&public_key).unwrap();
+        let decoded_public_key: PublicKey = from_value(encoded_public_key).unwrap();
+
+        assert_eq!(public_key, decoded_public_key);
+
+        let encoded_public_key = to_string(&public_key).unwrap();
+        let decoded_public_key: PublicKey = from_str(&encoded_public_key).unwrap();
 
         assert_eq!(public_key, decoded_public_key);
     }
@@ -117,6 +147,23 @@ mod test {
     fn serialize_deserialize_mini_secret_key() {
         let encoded_secret_key: Vec<u8> = serialize(&ED25519_SECRET_KEY).unwrap();
         let decoded_secret_key: MiniSecretKey = deserialize(&encoded_secret_key).unwrap();
+
+        for i in 0..32 {
+            assert_eq!(ED25519_SECRET_KEY.0[i], decoded_secret_key.0[i]);
+        }
+    }
+
+    #[test]
+    fn serialize_deserialize_mini_secret_key_json() {
+        let encoded_secret_key = to_value(&ED25519_SECRET_KEY).unwrap();
+        let decoded_secret_key: MiniSecretKey = from_value(encoded_secret_key).unwrap();
+
+        for i in 0..32 {
+            assert_eq!(ED25519_SECRET_KEY.0[i], decoded_secret_key.0[i]);
+        }
+
+        let encoded_secret_key = to_string(&ED25519_SECRET_KEY).unwrap();
+        let decoded_secret_key: MiniSecretKey = from_str(&encoded_secret_key).unwrap();
 
         for i in 0..32 {
             assert_eq!(ED25519_SECRET_KEY.0[i], decoded_secret_key.0[i]);


### PR DESCRIPTION
This PR addresses the issue outlined in #66.

2 new dependencies were added: `serde_bytes` to actually use when serializing and deserializing, and `cfg_if`, so deserialization can use `Bytes` when in no `alloc` context and `BytesBuf` otherwise, since the latter allows to deserialize from more data types where the size is not known or it is not borrowable, such as sequences.

`serde` has also been renamed in the manifest as `serde_crate`, similar to `curve25519-dalek`'s manifest, to allow bundling `serde_bytes` and `serde` in a single feature flag.

Tests were added to check compatibility with `serde_json`

Closes #66 