### PR TITLE
Standardise spellings in comments

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -76,7 +76,7 @@ impl SecretKey {
 }
 
 impl PublicKey {
-    /// Initalize an AEAD to the public key `self` using an ephemeral key exchange.
+    /// Initialize an AEAD to the public key `self` using an ephemeral key exchange.
     ///
     /// Returns the ephemeral public key and AEAD.
     pub fn init_aead_unauthenticated<AEAD: NewAead>(&self, ctx: &[u8]) -> (CompressedRistretto,AEAD)
@@ -86,7 +86,7 @@ impl PublicKey {
         (ephemeral.public.into_compressed(), aead)
     }
 
-    /// Initalize an AEAD to the public key `self` using an ephemeral key exchange.
+    /// Initialize an AEAD to the public key `self` using an ephemeral key exchange.
     ///
     /// Returns the ephemeral public key and AEAD.
     /// Requires the AEAD have a 32 byte public key and does not support a context.
@@ -168,7 +168,7 @@ impl Keypair {
     /// Sender's AEAD with Adaptor certificate.
     ///
     /// Along with the AEAD, we return the implicit Adaptor certificate
-    /// from which the reciever recreates the ephemeral public key.
+    /// from which the receiver recreates the ephemeral public key.
     pub fn sender_aead_with_adaptor_cert<T,AEAD>(&self, t: T, public: &PublicKey) -> (AdaptorCertPublic,AEAD)
     where T: SigningTranscript+Clone, AEAD: NewAead
     {

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -44,9 +44,9 @@ const ASSERT_MESSAGE: &'static str = "The number of messages/transcripts, signat
 ///
 /// # Returns
 ///
-/// * A `Result` whose `Ok` value is an emtpy tuple and whose `Err` value is a
+/// * A `Result` whose `Ok` value is an empty tuple and whose `Err` value is a
 ///   `SignatureError` containing a description of the internal error which
-///   occured.
+///   occurred.
 ///
 /// # Examples
 ///
@@ -105,7 +105,7 @@ impl rand_core::CryptoRng for NotAnRng {}
 /// [public key delinearization](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html).
 ///
 /// We caution deeterministic delinearization could interact poorly
-/// with other functionaltiy, *if* one delinarization scalar were
+/// with other functionality, *if* one delinarization scalar were
 /// left constant.  We do not make that mistake here.
 pub fn verify_batch_deterministic<T,I>(
     transcripts: I,
@@ -206,8 +206,8 @@ where
     assert!(transcripts.next().is_none(), "{}", ASSERT_MESSAGE);
     assert!(hrams.len() == public_keys.len(), "{}", ASSERT_MESSAGE);
 
-    // Use a random number generator keyed by both the publidc keys,
-    // and the system randomn number gnerator
+    // Use a random number generator keyed by both the public keys,
+    // and the system random number generator
     let mut csprng = zs_t.build_rng().finalize(&mut rng);
     // Select a random 128-bit scalar for each signature.
     // We may represent these as scalars because we use
@@ -272,7 +272,7 @@ fn verify_batch_equation(
         once(-bs).chain(zs.iter().cloned()).chain(hrams),
         B.chain(Rs).chain(As),
     ).map(|id| id.is_identity()).unwrap_or(false);
-    // We need not return SigenatureError::PointDecompressionError because
+    // We need not return SignatureError::PointDecompressionError because
     // the decompression failures occur for R represent invalid signatures.
 
     if b { Ok(()) } else { Err(SignatureError::EquationFalse) }
@@ -282,7 +282,7 @@ fn verify_batch_equation(
 
 /// Half-aggregated aka prepared batch signature
 /// 
-/// Implemntation of "Non-interactive half-aggregation of EdDSA and
+/// Implementation of "Non-interactive half-aggregation of EdDSA and
 /// variantsof Schnorr signatures" by  Konstantinos Chalkias,
 /// François Garillot, Yashvanth Kondi, and Valeria Nikolaenko
 /// available from https://eprint.iacr.org/2021/350.pdf
@@ -377,7 +377,7 @@ impl PreparedBatch{
         32 + 32 * self.Rs.len()
     }
 
-    /// Serializes into exacly sized buffer
+    /// Serializes into exactly sized buffer
     #[allow(non_snake_case)]
     pub fn write_bytes(&self, mut bytes: &mut [u8]) {
         assert!(bytes.len() == self.byte_len());        

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -8,10 +8,10 @@
 // - Jeffrey Burdges <jeff@web3.foundation>
 
 
-//! ### Adaptor siganture-based implicit certificate scheme for Ristretto
+//! ### Adaptor signature-based implicit certificate scheme for Ristretto
 //!
 //! [Implicit certificates](https://en.wikipedia.org/wiki/Implicit_certificate)
-//! provide an extremely space efficent public key certificate scheme.
+//! provide an extremely space efficient public key certificate scheme.
 //!
 //! As a rule, implicit certificates do not prove possession of the
 //! private key.  We thus worry more about fear rogue key attack when
@@ -84,7 +84,7 @@ impl From<AdaptorCertSecret> for AdaptorCertPublic {
 
 /// Adaptor Implicit Certificate Public Key Reconstruction Data
 ///
-/// Identifying the public key of, and implicity verifying, an Adaptor
+/// Identifying the public key of, and implicitly verifying, an Adaptor
 /// implicit certificate requires this data, which is produced
 /// when the certificate holder accepts the implicit certificate.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -140,7 +140,7 @@ impl PublicKey {
     ///
     /// We request an Adaptor implicit certificate by first creating an
     /// ephemeral `Keypair` and sending the public portion to the issuer
-    /// as `seed_public_key`.  An issuer issues the certificat by replying
+    /// as `seed_public_key`.  An issuer issues the certificate by replying
     /// with the `AdaptorCertSecret` created by `issue_adaptor_cert`.
     ///
     /// Aside from the issuer `PublicKey` supplied as `self`, you provide
@@ -188,12 +188,12 @@ impl Keypair {
     /// We can issue an implicit certificate to ourselves if we merely
     /// want to certify an associated public key.  We should prefer
     /// this option over "hierarchical deterministic" key derivation
-    /// because compromizing the resulting secret key does not
-    /// compromize the issuer's secret key.
+    /// because compromising the resulting secret key does not
+    /// compromise the issuer's secret key.
     ///
     /// In this case, we avoid the entire interactive protocol described
     /// by `issue_adaptor_cert` and `accept_adaptor_cert` by hiding it an all
-    /// managment of the ephemeral `Keypair` inside this function.
+    /// management of the ephemeral `Keypair` inside this function.
     ///
     /// Aside from the issuing secret key supplied as `self`, you provide
     /// only a digest `h` that incorporates any context and metadata
@@ -255,4 +255,3 @@ mod tests {
         assert_eq!(secret_key.to_public(), public_key);
     }
 }
-

--- a/src/context.rs
+++ b/src/context.rs
@@ -165,7 +165,7 @@ impl SigningTranscript for Transcript {
 
 /// Schnorr signing context
 ///
-/// We expect users to have seperate `SigningContext`s for each role
+/// We expect users to have separate `SigningContext`s for each role
 /// that signature play in their protocol.  These `SigningContext`s
 /// may be global `lazy_static!`s, or perhaps constants in future.
 ///
@@ -173,11 +173,11 @@ impl SigningTranscript for Transcript {
 /// a signature transcript.
 ///
 /// You should use `merlin::Transcript`s directly if you must do
-/// anything more complex, like use signatures in larger zero-knoweldge
+/// anything more complex, like use signatures in larger zero-knowledge
 /// protocols or sign several components but only reveal one later.
 ///
 /// We declare these methods `#[inline(always)]` because rustc does
-/// not handle large returns as efficently as one might like.
+/// not handle large returns as efficiently as one might like.
 /// https://github.com/rust-random/rand/issues/817
 #[derive(Clone)] // Debug
 pub struct SigningContext(Transcript);
@@ -199,7 +199,7 @@ impl SigningContext {
         SigningContext(t)
     }
 
-    /// Initalize an owned signing transcript on a message provided as a byte array.
+    /// Initialize an owned signing transcript on a message provided as a byte array.
     ///
     /// Avoid this method when processing large slices because it
     /// calls `merlin::Transcript::append_message` directly and
@@ -211,7 +211,7 @@ impl SigningContext {
         t
     }
 
-    /// Initalize an owned signing transcript on a message provided
+    /// Initialize an owned signing transcript on a message provided
     /// as a hash function with extensible output mode (XOF) by
     /// finalizing the hash and extracting 32 bytes from XOF.
     #[inline(always)]
@@ -223,7 +223,7 @@ impl SigningContext {
         t
     }
 
-    /// Initalize an owned signing transcript on a message provided as
+    /// Initialize an owned signing transcript on a message provided as
     /// a hash function with 256 bit output.
     #[inline(always)]
     pub fn hash256<D: FixedOutput<OutputSize=U32>>(&self, h: D) -> Transcript {
@@ -234,7 +234,7 @@ impl SigningContext {
         t
     }
 
-    /// Initalize an owned signing transcript on a message provided as
+    /// Initialize an owned signing transcript on a message provided as
     /// a hash function with 512 bit output, usually a gross over kill.
     #[inline(always)]
     pub fn hash512<D: FixedOutput<OutputSize=U64>>(&self, h: D) -> Transcript {
@@ -247,7 +247,7 @@ impl SigningContext {
 }
 
 
-/// Very simple transcript construction from a modern hash fucntion.
+/// Very simple transcript construction from a modern hash function.
 ///
 /// We provide this transcript type to directly use conventional hash
 /// functions with an extensible output mode, like Shake128 and
@@ -255,7 +255,7 @@ impl SigningContext {
 ///
 /// We recommend using `merlin::Transcript` instead because merlin
 /// provides the transcript abstraction natively and might function
-/// better in low memory enviroments.  We therefore do not provide
+/// better in low memory environments.  We therefore do not provide
 /// conveniences like `signing_context` for this.
 ///
 /// We note that merlin already uses Keccak, upon which Shake128 is based,

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -15,8 +15,8 @@
 //! derivation methods here.
 //! Attackers could translate malleable VRF outputs from one soft subkey 
 //! to another soft subkey, gaining early knowledge of the VRF output.
-//! We think most VRF applicaitons for which HDKH sounds suitable
-//! benefit from using implicit certificates insead of HDKD anyways,
+//! We think most VRF applications for which HDKH sounds suitable
+//! benefit from using implicit certificates instead of HDKD anyways,
 //! which should also be secure in combination with HDKH.
 //! We always use non-malleable VRF inputs in our convenience methods.
 
@@ -59,7 +59,7 @@ pub trait Derivation : Sized {
 
     /// Derive key with subkey identified by a byte array 
     /// and a chain code.  We do not include a context here
-    /// becuase the chain code could serve this purpose.
+    /// because the chain code could serve this purpose.
     fn derived_key_simple<B: AsRef<[u8]>>(&self, cc: ChainCode, i: B) -> (Self, ChainCode) {
         let mut t = merlin::Transcript::new(b"SchnorrRistrettoHDKD");
         t.append_message(b"sign-bytes", i.as_ref());
@@ -67,7 +67,7 @@ pub trait Derivation : Sized {
     }
 
     /// Derive key with subkey identified by a byte array
-    /// and a chain code, and with external ranodmnesses.
+    /// and a chain code, and with external randomnesses.
     fn derived_key_simple_rng<B,R>(&self, cc: ChainCode, i: B, rng: R) -> (Self, ChainCode)
     where B: AsRef<[u8]>, R: RngCore+CryptoRng
     {
@@ -109,11 +109,11 @@ impl SecretKey {
     /// trait.  We similarly do not believe hard derivations
     /// make any sense for `ChainCode`s or `ExtendedKey`s types.
     /// Yet, some existing BIP32 workflows might do these things,
-    /// due to BIP32's de facto stnadardization and poor design.
+    /// due to BIP32's de facto standardization and poor design.
     /// In consequence, we provide this method to do "hard" derivations
     /// in a way that should work with all BIP32 workflows and any
     /// permissible mutations of `SecretKey`.  This means only that
-    /// we hash the `SecretKey`'s scalar, but not its nonce becuase
+    /// we hash the `SecretKey`'s scalar, but not its nonce because
     /// the secret key remains valid if the nonce is changed.
     pub fn hard_derive_mini_secret_key<B: AsRef<[u8]>>(&self, cc: Option<ChainCode>, i: B)
      -> (MiniSecretKey,ChainCode)
@@ -142,11 +142,11 @@ impl MiniSecretKey {
     /// trait.  We similarly do not believe hard derivations
     /// make any sense for `ChainCode`s or `ExtendedKey`s types.
     /// Yet, some existing BIP32 workflows might do these things,
-    /// due to BIP32's de facto stnadardization and poor design.
+    /// due to BIP32's de facto standardization and poor design.
     /// In consequence, we provide this method to do "hard" derivations
     /// in a way that should work with all BIP32 workflows and any
     /// permissible mutations of `SecretKey`.  This means only that
-    /// we hash the `SecretKey`'s scalar, but not its nonce becuase
+    /// we hash the `SecretKey`'s scalar, but not its nonce because
     /// the secret key remains valid if the nonce is changed.
     pub fn hard_derive_mini_secret_key<B: AsRef<[u8]>>(&self, cc: Option<ChainCode>, i: B, mode: ExpansionMode)
      -> (MiniSecretKey,ChainCode)
@@ -163,11 +163,11 @@ impl Keypair {
     /// trait.  We similarly do not believe hard derivations
     /// make any sense for `ChainCode`s or `ExtendedKey`s types.
     /// Yet, some existing BIP32 workflows might do these things,
-    /// due to BIP32's de facto stnadardization and poor design.
+    /// due to BIP32's de facto standardization and poor design.
     /// In consequence, we provide this method to do "hard" derivations
     /// in a way that should work with all BIP32 workflows and any
     /// permissible mutations of `SecretKey`.  This means only that
-    /// we hash the `SecretKey`'s scalar, but not its nonce becuase
+    /// we hash the `SecretKey`'s scalar, but not its nonce because
     /// the secret key remains valid if the nonce is changed.
     pub fn hard_derive_mini_secret_key<B: AsRef<[u8]>>(&self, cc: Option<ChainCode>, i: B)
      -> (MiniSecretKey,ChainCode) {
@@ -185,7 +185,7 @@ impl Keypair {
 
         // We can define the nonce however we like here since it only protects
         // the signature from bad random number generators.  It need not be
-        // specified by any spcification or standard.  It must however be
+        // specified by any specification or standard.  It must however be
         // independent from the mutating scalar and new chain code.
         // We employ the witness mechanism here so that CSPRNG associated to our
         // `SigningTranscript` makes our new nonce seed independent from everything.
@@ -269,11 +269,11 @@ impl ExtendedKey<SecretKey> {
     /// trait.  We similarly do not believe hard derivations
     /// make any sense for `ChainCode`s or `ExtendedKey`s types.
     /// Yet, some existing BIP32 workflows might do these things,
-    /// due to BIP32's de facto stnadardization and poor design.
+    /// due to BIP32's de facto standardization and poor design.
     /// In consequence, we provide this method to do "hard" derivations
     /// in a way that should work with all BIP32 workflows and any
     /// permissible mutations of `SecretKey`.  This means only that
-    /// we hash the `SecretKey`'s scalar, but not its nonce becuase
+    /// we hash the `SecretKey`'s scalar, but not its nonce because
     /// the secret key remains valid if the nonce is changed.
     pub fn hard_derive_mini_secret_key<B: AsRef<[u8]>>(&self, i: B, mode: ExpansionMode)
      -> ExtendedKey<SecretKey> 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,7 @@ use core::fmt;
 use core::fmt::Display;
 
 
-/// `Result` specilized to this crate for convenience.
+/// `Result` specialized to this crate for convenience.
 pub type SignatureResult<T> = Result<T, SignatureError>;
 
 /// Three-round trip multi-signature stage identifies used in error reporting
@@ -46,7 +46,7 @@ impl Display for MultiSignatureStage {
 /// Errors which may occur while processing signatures and keypairs.
 ///
 /// All these errors represent a failed signature when they occur in
-/// the context of verifying a sitgnature, including in deserializaing
+/// the context of verifying a signature, including in deserializaing
 /// for verification.  We expose the distinction among them primarily
 /// for debugging purposes.
 ///
@@ -90,19 +90,19 @@ pub enum SignatureError {
     },
     /// Signature not marked as schnorrkel, maybe try ed25519 instead.
     NotMarkedSchnorrkel,
-    /// There is no record of the preceeding multi-signautre protocol
+    /// There is no record of the preceding multi-signautre protocol
     /// stage for the specified public key.
     MuSigAbsent {
         /// Identifies the multi-signature protocol stage during which
-        /// the error occured.
+        /// the error occurred.
         musig_stage: MultiSignatureStage,
     },
     /// For this public key, there are either conflicting records for
-    /// the preceeding multi-signautre protocol stage or else duplicate
+    /// the preceding multi-signautre protocol stage or else duplicate
     /// duplicate records for the current stage.
     MuSigInconsistent {
         /// Identifies the multi-signature protocol stage during which
-        /// the error occured.
+        /// the error occurred.
         musig_stage: MultiSignatureStage,
         /// Set true if the stage was reached correctly once but this
         /// duplicate disagrees.
@@ -175,4 +175,3 @@ where E: serde_crate::de::Error
         _ => panic!("Non-serialisation error encountered by serde!"),
     }
 }
-

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -71,16 +71,16 @@ pub enum ExpansionMode {
     /// ed25519-style bit clamping.
     ///
     /// Ristretto points are represented by Ed25519 points internally
-    /// so concievably some future standard might expose a mapping
+    /// so conceivably some future standard might expose a mapping
     /// from Ristretto to Ed25519, which makes this mode useful.
     /// At present, there is no such exposed mapping however because
     /// two such mappings actually exist, depending upon the branch of
     /// the inverse square root chosen by a Ristretto implementation.
     /// There is however a concern that such a mapping would remain
     /// a second class citizen, meaning implementations differ and
-    /// create incompatability.
+    /// create incompatibility.
     ///
-    /// We weakly recommend against emoloying this method.  We include
+    /// We weakly recommend against employing this method.  We include
     /// it primarily because early Ristretto documentation touted the
     /// relationship with Ed25519, which led to some deployments adopting
     /// this expansion method.
@@ -127,7 +127,7 @@ impl MiniSecretKey {
 
     /// Expand this `MiniSecretKey` into a `SecretKey`
     ///
-    /// We preoduce a secret keys using merlin and more uniformly
+    /// We produce a secret keys using merlin and more uniformly
     /// with this method, which reduces binary size and benefits
     /// some future protocols.
     ///
@@ -337,10 +337,10 @@ impl MiniSecretKey {
 serde_boilerplate!(MiniSecretKey);
 
 
-/// A seceret key for use with Ristretto Schnorr signatures.
+/// A secret key for use with Ristretto Schnorr signatures.
 ///
 /// Internally, these consist of a scalar mod l along with a seed for
-/// nonce generation.  In this way, we ensure all scalar arithmatic
+/// nonce generation.  In this way, we ensure all scalar arithmetic
 /// works smoothly in operations like threshold or multi-signatures,
 /// or hierarchical deterministic key derivations.
 ///
@@ -358,7 +358,7 @@ pub struct SecretKey {
     /// Seed for deriving the nonces used in signing.
     ///
     /// We require this be random and secret or else key compromise attacks will ensue.
-    /// Any modificaiton here may dirupt some non-public key derivation techniques.
+    /// Any modification here may disrupt some non-public key derivation techniques.
     pub (crate) nonce: [u8; 32],
 }
 
@@ -407,7 +407,7 @@ impl SecretKey {
     /// Convert this `SecretKey` into an array of 64 bytes with.
     ///
     /// Returns an array of 64 bytes, with the first 32 bytes being
-    /// the secret scalar represented cannonically, and the last
+    /// the secret scalar represented canonically, and the last
     /// 32 bytes being the seed for nonces.
     ///
     /// # Examples
@@ -484,7 +484,7 @@ impl SecretKey {
     }
 
     /* Unused tooling removed to reduce dependencies. 
-    /// Convert this `SecretKey` into an Ed25519 expanded secreyt key.
+    /// Convert this `SecretKey` into an Ed25519 expanded secret key.
     #[cfg(feature = "ed25519_dalek")]
     pub fn to_ed25519_expanded_secret_key(&self) -> ed25519_dalek::ExpandedSecretKey {
         ed25519_dalek::ExpandedSecretKey::from_bytes(&self.to_ed25519_bytes()[..])
@@ -575,7 +575,7 @@ serde_boilerplate!(SecretKey);
 ///
 /// At present, we decompress `PublicKey`s into this representation
 /// during deserialization, which improves error handling, but costs
-/// a compression during signing and verifiaction.
+/// a compression during signing and verification.
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PublicKey(pub (crate) RistrettoBoth);
 
@@ -730,7 +730,7 @@ impl Keypair {
     /// # Returns
     ///
     /// A byte array `[u8; KEYPAIR_LENGTH]` consisting of first a
-    /// `SecretKey` serialized cannonically, and next the Ristterro
+    /// `SecretKey` serialized canonically, and next the Ristterro
     /// `PublicKey`
     ///
     /// # Examples
@@ -865,7 +865,7 @@ impl Keypair {
     ///
     /// We generate a `SecretKey` directly bypassing `MiniSecretKey`,
     /// so our secret keys do not satisfy the high bit "clamping"
-    /// impoised on Ed25519 keys.
+    /// imposed on Ed25519 keys.
     pub fn generate_with<R>(csprng: R) -> Keypair
     where R: CryptoRng + RngCore,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //! ## Serialisation
 //!
 //! `PublicKey`s, `MiniSecretKey`s, `Keypair`s, and `Signature`s can be serialised
-//! into byte-arrays by calling `.to_bytes()`.  It's perfectly acceptible and
+//! into byte-arrays by calling `.to_bytes()`.  It's perfectly acceptable and
 //! safe to transfer and/or store those bytes.  (Of course, never transfer your
 //! secret key to anyone else, since they will only need the public key to
 //! verify your signatures!)

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -66,8 +66,8 @@ const REWINDS: usize = 3;
 ///
 /// Incorrect weightings shall occur if the iterator provided does not
 /// run in the same sorted ordering as `BTreeMap::iter`/`keys`/etc.
-/// We avoided a context: &'static [u8] here and in callers becuase they
-/// seem irreevant to the security arguments in the MuSig paper.
+/// We avoided a context: &'static [u8] here and in callers because they
+/// seem irrelevant to the security arguments in the MuSig paper.
 #[inline(always)]
 fn commit_public_keys<'a,I>(keys: I) -> Transcript
 where I: Iterator<Item=&'a PublicKey>
@@ -478,7 +478,7 @@ where K: Borrow<Keypair>, T: SigningTranscript+Clone
 {
     /// Initialize a multi-signature aka cosignature protocol run.
     ///
-    /// We encurage borrowing the `Keypair` to minimize copies of
+    /// We encourage borrowing the `Keypair` to minimize copies of
     /// the private key, so we provide the `Keypair::musig` method
     /// for the `K = &'k Keypair` case.  You could use `Rc` or `Arc`
     /// with this `MuSig::new` method, or even pass in an owned copy.
@@ -511,7 +511,7 @@ where K: Borrow<Keypair>, T: SigningTranscript+Clone
         self.stage.R_me.to_commitment().unwrap()
     }
 
-    /// Add a new cosigner's public key and associated `R` bypassing our commitmewnt phase.
+    /// Add a new cosigner's public key and associated `R` bypassing our commitment phase.
     pub fn add_their_commitment(&mut self, them: PublicKey, theirs: Commitment)
      -> SignatureResult<()>
     {
@@ -568,7 +568,7 @@ where K: Borrow<Keypair>, T: SigningTranscript+Clone
     }
 
     /// Add a new cosigner's public key and associated `R` bypassing our
-    /// commitmewnt phase.
+    /// commitment phase.
     ///
     /// We implemented defenses that reduce the risks posed by this
     /// method, but anyone who wishes provable security should heed
@@ -586,7 +586,7 @@ where K: Borrow<Keypair>, T: SigningTranscript+Clone
     /// (b) stateful, and (c) infrequently used, via some constrained
     /// channel like manually scanning QR code.  Almost all hardware
     /// wallets designs fail (b), but non-hardware wallets fail (a),
-    /// with the middle ground being only something like Pairty Signer.
+    /// with the middle ground being only something like Parity Signer.
     /// Also, any public keys controlled by an organization likely
     /// fail (c) too, making this only useful for individuals.
     pub fn add_trusted(&mut self, them: PublicKey, theirs: Reveal)
@@ -633,7 +633,7 @@ where K: Borrow<Keypair>, T: SigningTranscript+Clone
     }
 }
 
-/// Final cosigning stage  colelction
+/// Final cosigning stage collection
 #[allow(non_snake_case)]
 pub struct CosignStage {
     /// Collective `R` value

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -134,7 +134,7 @@ impl Signature {
         Ok(Signature{ R: CompressedRistretto(lower), s: check_scalar(upper) ? })
     }
 
-    /// Depricated construction of a `Signature` from a slice of bytes
+    /// Deprecated construction of a `Signature` from a slice of bytes
     /// without checking the bit distinguishing from ed25519.  Deprecated.
     #[cfg(feature = "preaudit_deprecated")]
     #[inline]
@@ -290,7 +290,7 @@ impl Keypair {
     /// # Examples
     ///
     /// Internally, we manage signature transcripts using a 128 bit secure
-    /// STROBE construction based on Keccak, which itself is extremly fast
+    /// STROBE construction based on Keccak, which itself is extremely fast
     /// and secure.  You might however influence performance or security
     /// by prehashing your message, like
     ///

--- a/src/vrf.rs
+++ b/src/vrf.rs
@@ -104,7 +104,7 @@ use crate::points::RistrettoBoth;
 /// 
 /// Greg Maxwell argue that nonce generation should hash all parameters
 /// that challenge generation does in https://moderncrypto.org/mail-archive/curves/2020/001012.html
-/// We support this position in prionciple as a defense in depth against
+/// We support this position in principle as a defense in depth against
 /// attacks that cause missalignment between the public and secret keys.
 ///
 /// We did this for signatures but not for the VRF deployed in Kusama.
@@ -152,14 +152,14 @@ impl<T> VRFSigningTranscript for T where T: SigningTranscript {
     }
 }
 
-/// VRF SigningTranscript for malleable VRF ouputs.
+/// VRF SigningTranscript for malleable VRF outputs.
 ///
 /// *Warning*  We caution that malleable VRF outputs are insecure when
 /// used in conjunction with HDKD, as provided in dervie.rs. 
 /// Attackers could translate malleable VRF outputs from one soft subkey 
 /// to another soft subkey, gaining early knowledge of the VRF output.
-/// We think most VRF applicaitons for which HDKH soudns suitable
-/// benefit from using implicit certificates insead of HDKD anyways,
+/// We think most VRF applications for which HDKH sounds suitable
+/// benefit from using implicit certificates instead of HDKD anyways,
 /// which should also be secure in combination with HDKD.
 /// We always use non-malleable VRF inputs in our convenience methods.
 #[derive(Clone)]
@@ -177,8 +177,8 @@ impl<T> VRFSigningTranscript for Malleable<T> where T: SigningTranscript {
 /// used in conjunction with HDKD, as provided in dervie.rs. 
 /// Attackers could translate malleable VRF outputs from one soft subkey 
 /// to another soft subkey, gaining early knowledge of the VRF output.
-/// We think most VRF applicaitons for which HDKH soudns suitable
-/// benefit from using implicit certificates insead of HDKD anyways,
+/// We think most VRF applications for which HDKH sounds suitable
+/// benefit from using implicit certificates instead of HDKD anyways,
 /// which should also be secure in combination with HDKH.
 /// We always use non-malleable VRF inputs in our convenience methods.
 pub fn vrf_malleable_hash<T: SigningTranscript>(mut t: T) -> RistrettoBoth {
@@ -216,7 +216,7 @@ pub type VRFOutput = VRFPreOut;
 /// We'd actually love to statically distinguish here between inputs
 /// and outputs, as well as whether outputs were verified, but doing
 /// so would disrupt our general purpose DLEQ proof mechanism, so
-/// users must be responcible for this themselves.  We do however
+/// users must be responsible for this themselves.  We do however
 /// consume by value in actual output methods, and do not implement
 /// `Copy`, as a reminder that VRF outputs should only be used once
 /// and should be checked before usage.
@@ -337,7 +337,7 @@ impl VRFInOut {
     /// If called with distinct contexts then outputs should be independent.
     ///
     /// We incorporate both the input and output to provide the 2Hash-DH
-    /// construction from Theorem 2 on page 32 in appendex C of
+    /// construction from Theorem 2 on page 32 in appendix C of
     /// ["Ouroboros Praos: An adaptively-secure, semi-synchronous proof-of-stake blockchain"](https://eprint.iacr.org/2017/573.pdf)
     /// by Bernardo David, Peter Gazi, Aggelos Kiayias, and Alexander Russell.
     pub fn make_bytes<B: Default + AsMut<[u8]>>(&self, context: &[u8]) -> B {
@@ -366,7 +366,7 @@ impl VRFInOut {
     /// Independent output streams are available via `ChaChaRng::set_stream` too.
     ///
     /// We incorporate both the input and output to provide the 2Hash-DH
-    /// construction from Theorem 2 on page 32 in appendex C of
+    /// construction from Theorem 2 on page 32 in appendix C of
     /// ["Ouroboros Praos: An adaptively-secure, semi-synchronous proof-of-stake blockchain"](https://eprint.iacr.org/2017/573.pdf)
     /// by Bernardo David, Peter Gazi, Aggelos Kiayias, and Alexander Russell.
     #[cfg(feature = "rand_chacha")]
@@ -657,7 +657,7 @@ impl Keypair {
     }
 
     /// Run VRF on one single input transcript, producing the outpus
-    /// and correspodning short proof.
+    /// and corresponding short proof.
     ///
     /// There are schemes like Ouroboros Praos in which nodes evaluate
     /// VRFs repeatedly until they win some contest.  In these case,
@@ -672,7 +672,7 @@ impl Keypair {
     }
 
     /// Run VRF on one single input transcript and an extra message transcript, 
-    /// producing the outpus and correspodning short proof.
+    /// producing the outpus and corresponding short proof.
     pub fn vrf_sign_extra<T,E>(&self, t: T, extra: E) -> (VRFInOut, VRFProof, VRFProofBatchable)
     where T: VRFSigningTranscript,
           E: SigningTranscript,
@@ -684,7 +684,7 @@ impl Keypair {
 
 
     /// Run VRF on one single input transcript, producing the outpus
-    /// and correspodning short proof only if the result first passes
+    /// and corresponding short proof only if the result first passes
     /// some check.
     ///
     /// There are schemes like Ouroboros Praos in which nodes evaluate
@@ -702,7 +702,7 @@ impl Keypair {
     }
 
     /// Run VRF on one single input transcript, producing the outpus
-    /// and correspodning short proof only if the result first passes
+    /// and corresponding short proof only if the result first passes
     /// some check, which itself returns an extra message transcript.
     pub fn vrf_sign_extra_after_check<T,E,F>(&self, t: T, mut check: F)
      -> Option<(VRFInOut, VRFProof, VRFProofBatchable)>
@@ -901,9 +901,9 @@ impl PublicKey {
 /// TODO: Assess when the two verification equations should be
 /// combined, presumably by benchmarking both forms.  At smaller batch
 /// sizes then we should clearly benefit form the combined form, but
-/// bany combination doubles the scalar by scalar multiplicications
+/// any combination doubles the scalar by scalar multiplications
 /// and hashing, so large enough batch verifications should favor two
-/// seperate calls.
+/// separate calls.
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[allow(non_snake_case)]
 pub fn dleq_verify_batch(
@@ -916,8 +916,8 @@ pub fn dleq_verify_batch(
     assert!(ps.len() == proofs.len(), "{}", ASSERT_MESSAGE);
     assert!(proofs.len() == public_keys.len(), "{}", ASSERT_MESSAGE);
 
-    // Use a random number generator keyed by the publidc keys, the
-    // inout and putput points, and the system randomn number gnerator.
+    // Use a random number generator keyed by the public keys, the
+    // inout and putput points, and the system random number generator.
     let mut csprng = {
         let mut t = Transcript::new(b"VB-RNG");
         for (pk,p) in public_keys.iter().zip(ps) {


### PR DESCRIPTION
I'm dyslexic and roll with a spellchecker. It picked up a few things so I thought I'd fix them.

*no source code changes*