### PR TITLE
Update to `curve25519-dalek` 4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ aead = { version = "0.5.2", default-features = false, optional = true }
 arrayref = { version = "0.3.6", default-features = false }
 # needs to match parity-scale-code which is "=0.7.0"
 arrayvec = { version = "0.7.0", default-features = false }
-curve25519-dalek = { version = "4.0.0-rc.2", default-features = false, features = ["digest", "zeroize"] }
+curve25519-dalek = { version = "4.1.0", default-features = false, features = ["digest", "zeroize", "precomputed-tables", "legacy_compatibility"] }
 subtle = { version = "2.5.0", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.2", default-features = false }
@@ -42,13 +42,12 @@ name = "schnorr_benchmarks"
 harness = false
 
 [features]
-default = ["std", "getrandom", "precomputed-tables"]
+default = ["std", "getrandom"]
 preaudit_deprecated = []
 nightly = []
 alloc = ["curve25519-dalek/alloc", "rand_core/alloc", "serde_bytes/alloc"]
 std = ["alloc", "getrandom", "serde_bytes/std"]
 asm = ["sha2/asm"]
-precomputed-tables = ["curve25519-dalek/precomputed-tables"]
 serde = ["serde_crate", "serde_bytes", "cfg-if"]
 # We cannot make getrandom a direct dependency because rand_core makes
 # getrandom a feature name, which requires forwarding.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -147,16 +147,5 @@ impl failure::Fail for SignatureError {}
 pub fn serde_error_from_signature_error<E>(err: SignatureError) -> E
 where E: serde_crate::de::Error
 {
-    use self::SignatureError::*;
-    match err {
-        PointDecompressionError
-            => E::custom("Ristretto point decompression failed"),
-        ScalarFormatError
-            => E::custom("improper scalar has high-bit set"),  // TODO ed25519 v high 3 bits?
-        BytesLengthError{ description, length, .. }
-            => E::invalid_length(length, &description),
-        NotMarkedSchnorrkel
-            => E::custom("Signature bytes not marked as a schnorrkel signature"),
-        _ => panic!("Non-serialisation error encountered by serde!"),
-    }
+    E::custom(err)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,6 +75,8 @@ pub enum SignatureError {
     PointDecompressionError,
     /// Invalid scalar provided, usually to `Signature::from_bytes`.
     ScalarFormatError,
+    /// The provided key is not valid.
+    InvalidKey,
     /// An error in the length of bytes handed to a constructor.
     ///
     /// To use this, pass a string specifying the `name` of the type
@@ -120,6 +122,8 @@ impl Display for SignatureError {
                 write!(f, "Cannot decompress Ristretto point"),
             ScalarFormatError =>
                 write!(f, "Cannot use scalar with high-bit set"),
+            InvalidKey =>
+                write!(f, "The provided key is not valid"),
             BytesLengthError { name, length, .. } =>
                 write!(f, "{name} must be {length} bytes in length"),
             NotMarkedSchnorrkel => 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 #![allow(clippy::needless_lifetimes)]
 
-#[cfg(any(feature = "std"))]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -72,7 +72,8 @@ pub(crate) fn check_scalar(bytes: [u8; 32]) -> SignatureResult<Scalar> {
     // as the order of the basepoint is roughly a 2^(252.5) bit number.
     //
     // This succeed-fast trick should succeed for roughly half of all scalars.
-    if bytes[31] & 240 == 0 {
+    if bytes[31] & 0b11110000 == 0 {
+        #[allow(deprecated)] // Scalar's always reduced here, so this is OK.
         return Ok(Scalar::from_bits(bytes))
     }
 


### PR DESCRIPTION
This PR updates `curve25519-dalek` to 4.1.0, which (among other things) will detect and use an appropriate SIMD backend at runtime, which should speed things up.

One notable change is that the `Scalar::from_bits` is now deprecated as it requires the scalar to be reduced (and this is not verified) otherwise operations other than multiplications will be broken. We use this three times, and two of those uses are always valid (the scalars passed there are AFAIK always guaranteed to be reduced). For the third one in `SecretKey::from_ed25519_bytes` I've just made it check that this is the case. (So now that function will return an error when passed an invalid key.)

I've also removed the `precomputed-tables` feature flag because disabling it seems to be broken anyway: when it's disabled the crate doesn't compile anymore.