### PR TITLE
Test `no_std` builds on a target lacking `std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,14 +19,22 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo test
 
-  build:
-    name: Build (no_std)
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - run: cargo build --no-default-features
-    - run: cargo build --no-default-features --features alloc
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - name: no_std / no feat
+        run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      # cargo hack ensures all no_std features all built-checked
+      - name: no_std / cargo hack features
+        run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,getrandom
 
   clippy:
     name: Check that clippy is happy


### PR DESCRIPTION
This has bitten me more times than I care to admit :)

So here is a build-test for `no_std` that ensures build on a target that lacks std - default target would have std available.

It also tests all the features properly when / if introduced automatically unless excluded as std e.g. `getrandom` / `std`

We use the same in [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek/blob/main/.github/workflows/workspace.yml#L60C1-L81C148)