### PR TITLE
Adapt ::aead to name change of NewAead to KeyInit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ getrandom = ["rand_core/getrandom"]
 # wasm-bindgen = ["getrandom/wasm-bindgen"]
 # See https://github.com/rust-lang/cargo/issues/9210
 # and https://github.com/w3f/schnorrkel/issues/65#issuecomment-786923588
+aead = ["dep:aead", "getrandom"]

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -51,7 +51,7 @@ impl SecretKey {
     /// Commit the results of a key exchange into a transcript
     #[inline(always)]
     pub(crate) fn raw_key_exchange(&self, public: &PublicKey) -> CompressedRistretto {
-        (&self.key * public.as_point()).compress()
+        (self.key * public.as_point()).compress()
     }
 
     /// Commit the results of a raw key exchange into a transcript
@@ -141,7 +141,7 @@ impl Keypair {
     where T: SigningTranscript, AEAD: KeyInit
     {
         let key = t.witness_scalar(b"make_esk", &[&self.secret.nonce]);
-        let ekey = SecretKey { key, nonce: self.secret.nonce.clone() }.to_keypair();
+        let ekey = SecretKey { key, nonce: self.secret.nonce }.to_keypair();
         ekey.commit_key_exchange(&mut t,b"epk",public);
         self.commit_key_exchange(&mut t,b"epk",public);
         (ekey.public.into_compressed(), make_aead(t))
@@ -172,7 +172,7 @@ impl Keypair {
     where T: SigningTranscript+Clone, AEAD: KeyInit
     {
         let (cert,secret) = self.issue_self_adaptor_cert(t);
-        let aead = secret.to_keypair().aead_unauthenticated(b"",&public);
+        let aead = secret.to_keypair().aead_unauthenticated(b"", public);
         (cert, aead)
     }
 }

--- a/src/points.rs
+++ b/src/points.rs
@@ -156,7 +156,7 @@ impl PartialEq<Self> for RistrettoBoth {
 
 impl PartialOrd<RistrettoBoth> for RistrettoBoth {
     fn partial_cmp(&self, other: &RistrettoBoth) -> Option<::core::cmp::Ordering> {
-        self.compressed.0.partial_cmp(&other.compressed.0)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
I'm interested in using schnorrkel derived keys as DH keys, but the `::aead` module seems unfinished: can not compile, lacks documentation, etc.

A first commit adapts to the name change of `NewAead` to `KeyInit` in aead crate (https://github.com/w3f/schnorrkel/issues/90), while I look forward to finishing the module along the line.