### PR TITLE
set minimum subtle version to 2.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ curve25519-dalek = { version = "4.1.0", default-features = false, features = [
     "precomputed-tables",
     "legacy_compatibility",
 ] }
-subtle = { version = "2.5.0", default-features = false }
+subtle = { version = "2.4.1", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 getrandom_or_panic = { version = "0.0.3", default-features = false }
 rand_core = { version = "0.6.2", default-features = false }


### PR DESCRIPTION
This is to help with https://github.com/paritytech/polkadot-sdk/pull/2524#issuecomment-1847055347. If you agree with this change and merge it please release schnorrkel 0.11.4 afterwards.