### PR TITLE
Fix outdated links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # schnorrkel [![](https://img.shields.io/crates/v/schnorrkel.svg)](https://crates.io/crates/schnorrkel) [![](https://docs.rs/schnorrkel/badge.svg)](https://docs.rs/schnorrkel) [![](https://travis-ci.org/w3f/schnorrkel.svg?branch=master)](https://travis-ci.org/w3f/schnorrkel?branch=master)
 
 
-Schnorrkel implements Schnorr signature on [Ristretto](https://ristretto.group) compressed Ed25519 points, as well as [related](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) protocols like HDKD, [MuSig](https://eprint.iacr.org/2018/068), and a verifiable random function (VRF).  
+Schnorrkel implements Schnorr signature on [Ristretto](https://ristretto.group) compressed Ed25519 points, as well as [related](https://github.com/sipa/bips/blob/bip-taproot/bip-0340.mediawiki) protocols like HDKD, [MuSig](https://eprint.iacr.org/2018/068), and a verifiable random function (VRF).  
 
-[Ristretto](https://doc.dalek.rs/curve25519_dalek/ristretto/index.html) implements roughly section 7 of Mike Hamburg's [Decaf](https://eprint.iacr.org/2015/673.pdf) paper to provide the 2-torsion free points of the Ed25519 curve as a prime order group.  ([related](https://forum.web3.foundation/t/account-signatures-and-keys-in-polkadot/70/3?u=burdges))
+[Ristretto](https://doc.dalek.rs/curve25519_dalek/ristretto/index.html) implements roughly section 7 of Mike Hamburg's [Decaf](https://eprint.iacr.org/2015/673.pdf) paper to provide the 2-torsion free points of the Ed25519 curve as a prime order group.  ([related](https://research.web3.foundation/Polkadot/security/keys/accounts-more))
 
 We employ the [merlin](https://github.com/dalek-cryptography/merlin) strategy of [type specific hashing methods](https://docs.rs/merlin/1.0.3/merlin/struct.Transcript.html) with sound domain separation.  These wrap Mike Hamburg's [STROBE128](https://strobe.sourceforge.io) construction for symmetric cryptography, itself based on Keccak.  
 

--- a/annoucement.md
+++ b/annoucement.md
@@ -2,7 +2,7 @@
 
 We are pleased to announce the wire format stabilisation of the primary feature set of our [schnorrkel](https://github.com/w3f/schnorrkel) crate ([docs](https://docs.rs/schnorrkel)), which provides safer access to basic functionality now expected from signatures on blockchains.  In particular, schnorrkel provides Schnorr signatures, a fast Schnorr DLEQ proof based VRF, hierarchical deterministic key derivation (HDKD), and the safest currently known three round trip Schnorr multi-signature variant.
 
-We want more diverse functionality from signatures used in blockchain applications than from signatures used only in TLS, PGP, etc.  Schnorr signatures support more [functionality](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) than ECDSA, and do so far more simply.  In particular, multi-signatures and threshold signatures are vastly simpler with Schnorr signatures.  
+We want more diverse functionality from signatures used in blockchain applications than from signatures used only in TLS, PGP, etc.  Schnorr signatures support more [functionality](https://github.com/sipa/bips/blob/bip-taproot/bip-0340.mediawiki) than ECDSA, and do so far more simply.  In particular, multi-signatures and threshold signatures are vastly simpler with Schnorr signatures.  
 
 Also, the security arguments for Schnorr signatures require only standard assumptions plus the hash function being a random oracle.  By comparison, ECDSA arguments employ ad hoc dubious assumptions like an elliptic curve point compression function being a random oracle.  The simpler arguments ror Schnorr more often provide clear answers about the security of Schnorr composed with other protocols.
 


### PR DESCRIPTION
I just noticed that both "related" links in the readme are outdated, one for the Schnorr BIP and the other one for the web3 docs; this PR updates both links (although I'm not 100% sure if the latter one references the original doc).