### PR TITLE
Bump curve25519-dalek to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ aead = { version = "0.5.2", default-features = false, optional = true }
 arrayref = { version = "0.3.7", default-features = false }
 # needs to match parity-scale-code which is "=0.7.0"
 arrayvec = { version = "0.7.4", default-features = false }
-curve25519-dalek = { version = "4.1.0", default-features = false, features = [
+curve25519-dalek = { version = "4.1.2", default-features = false, features = [
     "digest",
     "zeroize",
     "precomputed-tables",


### PR DESCRIPTION

Bump curve25519-dalek to fix nighlty build Issue

 https://github.com/dalek-cryptography/curve25519-dalek/pull/619
 
 
 ```
 error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.2/src/backend/vector/ifma/field.rs:26:5
   |
26 |     _mm256_madd52lo_epu64(z.into(), x.into(), y.into()).into()
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.2/src/backend/vector/ifma/field.rs:25:9
   |
25 |     use core::arch::x86_64::_mm256_madd52lo_epu64;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.2/src/backend/vector/ifma/field.rs:34:5
   |
34 |     _mm256_madd52hi_epu64(z.into(), x.into(), y.into()).into()
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'stdsimd'
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.2/src/backend/vector/ifma/field.rs:33:9
   |
33 |     use core::arch::x86_64::_mm256_madd52hi_epu64;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information
   = help: add `#![feature(stdsimd)]` to the crate attributes to enable

error[E0635]: unknown feature `stdarch_x86_avx512`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.2/src/lib.rs:19:13
   |
19 |     feature(stdarch_x86_avx512)
   |             ^^^^^^^^^^^^^^^^^^
 ```