### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ aead = { version = "0.5.2", default-features = false, optional = true }
 arrayref = { version = "0.3.7", default-features = false }
 # needs to match parity-scale-code which is "=0.7.0"
 arrayvec = { version = "0.7.4", default-features = false }
-curve25519-dalek = { version = "4.1.0", default-features = false, features = [
+curve25519-dalek = { version = "4.1.3", default-features = false, features = [
     "digest",
     "zeroize",
     "precomputed-tables",


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)