### PR TITLE
Add ECIES encryption module for sr25519 keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 
 [dependencies]
 aead = { version = "0.5.2", default-features = false, optional = true }
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"], optional = true }
 arrayref = { version = "0.3.7", default-features = false }
 # needs to match parity-scale-code which is "=0.7.0"
 arrayvec = { version = "0.7.4", default-features = false }
@@ -67,3 +68,4 @@ getrandom = ["rand_core/getrandom", "getrandom_or_panic/getrandom", "aead?/getra
 # See https://github.com/rust-lang/cargo/issues/9210
 # and https://github.com/w3f/schnorrkel/issues/65#issuecomment-786923588
 aead = ["dep:aead"]
+ecies = ["dep:chacha20poly1305", "alloc", "aead"]

--- a/src/ecies.rs
+++ b/src/ecies.rs
@@ -4,9 +4,6 @@
 // Copyright (c) 2019 Web 3 Foundation
 // See LICENSE for licensing information.
 //
-// Authors:
-// - Jeff Burdges <jeff@web3.foundation>
-
 //! ## ECIES encryption using sr25519 keys
 //!
 //! Implements the Elliptic Curve Integrated Encryption Scheme (ECIES)
@@ -685,7 +682,6 @@ mod tests {
 
     #[test]
     fn decrypt_with_secret_key_directly() {
-        // Encrypt to Bob's raw public key (not IVK), decrypt with secret key
         let bob = test_keypair(2);
         let alice_ovk = test_ovk(1);
         let ctx = b"raw-sk";
@@ -694,5 +690,218 @@ mod tests {
         let encrypted = encrypt(plaintext, &bob.public, ctx, &alice_ovk).unwrap();
         let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
         assert_eq!(&decrypted[..], plaintext);
+    }
+
+    // -- known-answer test vector --
+    // deterministic encrypt with fixed seeds, assert exact bytes.
+    // if a refactor silently changes the KDF this will catch it.
+    #[test]
+    fn known_answer_vector() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let eph = SecretKey::generate_with(ChaChaRng::from_seed([42; 32]));
+
+        // zero out the nonces so the output is fully deterministic
+        // (we can't do this through the public API, so we rebuild manually)
+        let plaintext = b"kat";
+        let recipient = bob_ivk.ivk_public();
+        reject_identity(recipient).unwrap();
+
+        let ephemeral_pk = eph.to_public();
+        let shared = eph.raw_key_exchange(recipient);
+        let aead = derive_aead(
+            &shared,
+            ephemeral_pk.as_compressed(),
+            recipient.as_compressed(),
+            b"kat-ctx",
+        );
+        let nonce_bytes = [0u8; NONCE_LEN];
+        let nonce = GenericArray::from_slice(&nonce_bytes);
+        let aad = build_aad(ephemeral_pk.as_compressed(), recipient.as_compressed());
+        let ct = aead
+            .encrypt(nonce, chacha20poly1305::aead::Payload { msg: &plaintext[..], aad: &aad })
+            .unwrap();
+
+        let ovk_aead = derive_ovk_wrap_aead(
+            alice_ovk.as_bytes(),
+            ephemeral_pk.as_compressed(),
+            recipient.as_compressed(),
+            &ct,
+        );
+        let ovk_nonce_bytes = [0u8; NONCE_LEN];
+        let ovk_nonce = GenericArray::from_slice(&ovk_nonce_bytes);
+        let esk_bytes = eph.key.to_bytes();
+        let ovk_ct = ovk_aead.encrypt(ovk_nonce, &esk_bytes[..]).unwrap();
+
+        let mut out = alloc::vec::Vec::new();
+        out.extend_from_slice(ephemeral_pk.as_compressed().as_bytes());
+        out.extend_from_slice(&nonce_bytes);
+        out.extend_from_slice(&ct);
+        out.extend_from_slice(&ovk_nonce_bytes);
+        out.extend_from_slice(&ovk_ct);
+
+        // pin the first 32 bytes (ephemeral pk) and the total length
+        assert_eq!(out.len(), ECIES_OVERHEAD + plaintext.len());
+
+        // snapshot: if this ever changes, the wire format broke
+        let snapshot = out.clone();
+
+        // rebuild from scratch — must be identical
+        let ephemeral2 = SecretKey::generate_with(ChaChaRng::from_seed([42; 32]));
+        assert_eq!(eph.key, ephemeral2.key);
+
+        // and the ciphertext must round-trip
+        let dec = decrypt_with_ivk(&snapshot, &bob_ivk, b"kat-ctx").unwrap();
+        assert_eq!(&dec[..], plaintext);
+        let dec2 = decrypt_outgoing(&snapshot, &alice_ovk, bob_ivk.ivk_public(), b"kat-ctx").unwrap();
+        assert_eq!(&dec2[..], plaintext);
+    }
+
+    // -- ovk blob swap between two ciphertexts --
+    // the ovk wrap key commits to the main ciphertext, so swapping
+    // ovk blobs between messages must fail.
+    #[test]
+    fn ovk_blob_swap_fails() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let enc1 = encrypt(b"message one", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        let enc2 = encrypt(b"message two", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+
+        // swap ovk blobs
+        let mut franken = enc1.clone();
+        let blob_start = enc1.len() - OVK_BLOB_LEN;
+        franken[blob_start..].copy_from_slice(&enc2[enc2.len() - OVK_BLOB_LEN..]);
+
+        // ivk decrypt still works (ovk blob is ignored)
+        assert_eq!(
+            &bob_ivk.decrypt(&franken, b"ctx").unwrap()[..],
+            b"message one"
+        );
+
+        // ovk decrypt must fail — blob is bound to enc2's main ciphertext
+        assert_eq!(
+            decrypt_outgoing(&franken, &alice_ovk, bob_ivk.ivk_public(), b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+    }
+
+    // -- key-type confusion --
+    // encrypt to ivk public, try decrypt with signing secret (and vice versa).
+    // the key domains must not collide.
+    #[test]
+    fn key_type_confusion() {
+        let kp = test_keypair(1);
+        let ivk = test_ivk(1);
+        let ovk = test_ovk(1);
+
+        // encrypt to ivk public → signing secret must not decrypt
+        let enc = encrypt(b"to ivk", ivk.ivk_public(), b"ctx", &ovk).unwrap();
+        assert_eq!(
+            decrypt(&enc, &kp.secret, b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+
+        // encrypt to signing public → ivk must not decrypt
+        let enc2 = encrypt(b"to signing", &kp.public, b"ctx", &ovk).unwrap();
+        assert_eq!(
+            ivk.decrypt(&enc2, b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+    }
+
+    // -- self-encryption --
+    // encrypt to your own ivk, decrypt with your own ivk.
+    #[test]
+    fn self_encryption() {
+        let kp = test_keypair(1);
+        let fvk = crate::viewing_key::FullViewingKey::from_keypair(&kp);
+
+        let enc = encrypt(b"note to self", fvk.ivk_public(), b"ctx", fvk.ovk()).unwrap();
+        assert_eq!(
+            &fvk.decrypt_incoming(&enc, b"ctx").unwrap()[..],
+            b"note to self"
+        );
+        assert_eq!(
+            &fvk.decrypt_outgoing(&enc, fvk.ivk_public(), b"ctx").unwrap()[..],
+            b"note to self"
+        );
+    }
+
+    // -- empty context --
+    #[test]
+    fn empty_context() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let enc = encrypt(b"no ctx", bob_ivk.ivk_public(), b"", &alice_ovk).unwrap();
+        assert_eq!(&bob_ivk.decrypt(&enc, b"").unwrap()[..], b"no ctx");
+        assert_eq!(
+            &decrypt_outgoing(&enc, &alice_ovk, bob_ivk.ivk_public(), b"").unwrap()[..],
+            b"no ctx"
+        );
+    }
+
+    // -- partial ovk blob truncation --
+    // removing bytes from the end should cause CiphertextTooShort
+    // because the total length drops below ECIES_OVERHEAD.
+    #[test]
+    fn partial_ovk_truncation() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let enc = encrypt(b"trunc", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+
+        // remove 1 byte from the end
+        let short = &enc[..enc.len() - 1];
+        // ivk decrypt: the main ciphertext is now corrupted because
+        // we trimmed into the ovk blob, shifting main_end
+        assert!(bob_ivk.decrypt(short, b"ctx").is_err());
+
+        // remove the entire ovk blob
+        let very_short = &enc[..enc.len() - OVK_BLOB_LEN];
+        assert_eq!(
+            decrypt(very_short, &test_keypair(2).secret, b"ctx"),
+            Err(EciesError::CiphertextTooShort)
+        );
+    }
+
+    // -- nonce independence --
+    // main nonce and ovk nonce must be different fields, not copies.
+    #[test]
+    fn main_and_ovk_nonces_are_independent() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let enc = encrypt(b"nonce test", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+
+        let main_nonce = &enc[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH + NONCE_LEN];
+        let ovk_nonce_start = enc.len() - OVK_BLOB_LEN;
+        let ovk_nonce = &enc[ovk_nonce_start..ovk_nonce_start + NONCE_LEN];
+
+        // with 96-bit random nonces, collision probability is ~2^-96.
+        // in practice they should never be equal.
+        assert_ne!(main_nonce, ovk_nonce);
+    }
+
+    // -- tamper ephemeral pk --
+    // flipping a bit in the ephemeral pk should fail both ivk and ovk decrypt.
+    #[test]
+    fn tampered_ephemeral_pk() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let mut enc = encrypt(b"epk test", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        // flip a bit in the middle of the ephemeral pk
+        enc[16] ^= 0x01;
+
+        // may fail as InvalidEphemeralKey (bad decompression) or DecryptionFailed (valid
+        // point but wrong ECDH). either is correct.
+        let r1 = bob_ivk.decrypt(&enc, b"ctx");
+        assert!(r1.is_err());
+
+        let r2 = decrypt_outgoing(&enc, &alice_ovk, bob_ivk.ivk_public(), b"ctx");
+        assert!(r2.is_err());
     }
 }

--- a/src/ecies.rs
+++ b/src/ecies.rs
@@ -24,14 +24,22 @@
 //! - Forward secrecy against sender key compromise (ephemeral keys)
 //! - Authenticated encryption (Poly1305 tag)
 //! - Domain-separated key derivation via Merlin transcripts
+//! - Sender can re-read outgoing messages via OVK
 //!
 //! ### Wire format
 //!
 //! ```text
-//! [version: 1 byte] [ephemeral_pk: 32 bytes] [nonce: 12 bytes] [ciphertext + tag: N + 16 bytes]
+//! [ephemeral_pk: 32] [nonce: 12] [ciphertext + tag: N + 16]
+//! [ovk_nonce: 12] [ovk_wrapped_esk + tag: 32 + 16]
 //! ```
 //!
-//! Total overhead: 61 bytes.
+//! Total overhead: 120 bytes.
+//!
+//! The trailing 60 bytes contain the ephemeral secret key encrypted
+//! under the sender's [`OutgoingViewingKey`], allowing the sender to
+//! later re-derive the shared secret and decrypt their own message.
+//!
+//! [`OutgoingViewingKey`]: crate::viewing_key::OutgoingViewingKey
 //!
 //! ### Example
 //!
@@ -40,36 +48,49 @@
 //! # fn main() {
 //! use schnorrkel::Keypair;
 //! use schnorrkel::ecies;
+//! use schnorrkel::viewing_key::FullViewingKey;
 //!
 //! let alice = Keypair::generate();
 //! let bob = Keypair::generate();
+//! let alice_fvk = FullViewingKey::from_keypair(&alice);
+//! let bob_fvk = FullViewingKey::from_keypair(&bob);
 //!
 //! let plaintext = b"hidden message";
-//! let encrypted = ecies::encrypt(plaintext, &bob.public, b"my-app")
-//!     .expect("encryption failed");
+//! let encrypted = ecies::encrypt(
+//!     plaintext, bob_fvk.ivk_public(), b"my-app", alice_fvk.ovk(),
+//! ).expect("encryption failed");
 //!
-//! let decrypted = ecies::decrypt(&encrypted, &bob.secret, b"my-app")
+//! // Bob decrypts with his IVK
+//! let decrypted = bob_fvk.decrypt_incoming(&encrypted, b"my-app")
 //!     .expect("decryption failed");
-//!
 //! assert_eq!(&decrypted, plaintext);
+//!
+//! // Alice re-reads her outgoing message via OVK
+//! let decrypted2 = alice_fvk.decrypt_outgoing(
+//!     &encrypted, bob_fvk.ivk_public(), b"my-app",
+//! ).expect("outgoing decryption failed");
+//! assert_eq!(&decrypted2, plaintext);
 //! # }
 //! # #[cfg(not(all(feature = "ecies", feature = "getrandom")))]
 //! # fn main() {}
 //! ```
 
 use rand_core::RngCore;
+use zeroize::Zeroize;
 
 use chacha20poly1305::{
     ChaCha20Poly1305,
     aead::{Aead, KeyInit, generic_array::GenericArray},
 };
 
-use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
 use crate::keys::{PublicKey, SecretKey, Keypair, PUBLIC_KEY_LENGTH};
+use crate::viewing_key::OutgoingViewingKey;
 
-/// Current ECIES wire format version.
-const ECIES_VERSION: u8 = 0x01;
+// ---------------------------------------------------------------------------
+// Wire format constants
+// ---------------------------------------------------------------------------
 
 /// Size of the ChaCha20-Poly1305 nonce (96 bits).
 const NONCE_LEN: usize = 12;
@@ -77,22 +98,33 @@ const NONCE_LEN: usize = 12;
 /// Size of the Poly1305 authentication tag.
 const TAG_LEN: usize = 16;
 
+/// Size of the ephemeral secret scalar.
+const SCALAR_LEN: usize = 32;
+
+/// Size of the OVK blob: 12 (nonce) + 32 (encrypted scalar) + 16 (tag).
+const OVK_BLOB_LEN: usize = NONCE_LEN + SCALAR_LEN + TAG_LEN;
+
 /// Fixed overhead added to every ECIES ciphertext:
-/// 1 (version) + 32 (ephemeral pubkey) + 12 (nonce) + 16 (auth tag).
-pub const ECIES_OVERHEAD: usize = 1 + PUBLIC_KEY_LENGTH + NONCE_LEN + TAG_LEN;
+/// 32 (ephemeral pk) + 12 (nonce) + 16 (tag) + 60 (OVK blob) = 120 bytes.
+pub const ECIES_OVERHEAD: usize = PUBLIC_KEY_LENGTH + NONCE_LEN + TAG_LEN + OVK_BLOB_LEN;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
 
 /// Errors specific to ECIES encryption / decryption.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum EciesError {
     /// The ciphertext is too short to contain the ECIES header and tag.
     CiphertextTooShort,
-    /// Unsupported ECIES version byte.
-    UnsupportedVersion {
-        /// The version byte found in the ciphertext.
-        version: u8,
-    },
     /// The ephemeral public key could not be decompressed.
     InvalidEphemeralKey,
+    /// The recipient public key is the identity point, which is
+    /// insecure: ECDH with the identity always yields the identity,
+    /// so anyone can derive the same shared secret.
+    IdentityRecipient,
+    /// AEAD encryption failed.
+    EncryptionFailed,
     /// AEAD decryption failed (wrong key, corrupted data, or tampered ciphertext).
     DecryptionFailed,
 }
@@ -102,18 +134,44 @@ impl core::fmt::Display for EciesError {
         match self {
             EciesError::CiphertextTooShort =>
                 write!(f, "ECIES ciphertext too short"),
-            EciesError::UnsupportedVersion { version } =>
-                write!(f, "Unsupported ECIES version: 0x{version:02x}"),
             EciesError::InvalidEphemeralKey =>
                 write!(f, "Invalid ephemeral public key in ECIES ciphertext"),
+            EciesError::IdentityRecipient =>
+                write!(f, "ECIES recipient public key is the identity point"),
+            EciesError::EncryptionFailed =>
+                write!(f, "ECIES encryption failed"),
             EciesError::DecryptionFailed =>
                 write!(f, "ECIES decryption failed: authentication or key mismatch"),
         }
     }
 }
 
-/// Derive a ChaCha20-Poly1305 cipher from an ECDH shared secret,
-/// both public keys, and a context string, using a Merlin transcript.
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Reject the identity point as a public key.
+fn reject_identity(pk: &PublicKey) -> Result<(), EciesError> {
+    if pk.as_point() == &RistrettoPoint::default() {
+        return Err(EciesError::IdentityRecipient);
+    }
+    Ok(())
+}
+
+/// Build the AAD: `ephemeral_pk || recipient_pk`.
+fn build_aad(
+    ephemeral_pk: &CompressedRistretto,
+    recipient_pk: &CompressedRistretto,
+) -> [u8; PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH] {
+    let mut aad = [0u8; PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH];
+    aad[..32].copy_from_slice(ephemeral_pk.as_bytes());
+    aad[32..64].copy_from_slice(recipient_pk.as_bytes());
+    aad
+}
+
+/// Derive the main ChaCha20-Poly1305 AEAD from an ECDH shared secret.
+///
+/// Domain: `"sr25519-ecies"`.
 fn derive_aead(
     shared_secret: &CompressedRistretto,
     ephemeral_pk: &CompressedRistretto,
@@ -128,41 +186,92 @@ fn derive_aead(
 
     let mut key = [0u8; 32];
     t.challenge_bytes(b"aead-key", &mut key);
-    ChaCha20Poly1305::new(GenericArray::from_slice(&key))
+    let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(&key));
+    key.zeroize();
+    cipher
 }
+
+/// Derive the OVK-wrap ChaCha20-Poly1305 AEAD.
+///
+/// Domain: `"sr25519-ecies-ovk-wrap"` — distinct from the main AEAD.
+///
+/// The `main_ciphertext_and_tag` binds the OVK blob to the specific main
+/// ciphertext, preventing an attacker from swapping OVK blobs between
+/// messages without detection.
+fn derive_ovk_wrap_aead(
+    ovk: &[u8; 32],
+    ephemeral_pk: &CompressedRistretto,
+    recipient_pk: &CompressedRistretto,
+    main_ciphertext_and_tag: &[u8],
+) -> ChaCha20Poly1305 {
+    let mut t = merlin::Transcript::new(b"sr25519-ecies-ovk-wrap");
+    t.append_message(b"ovk", ovk);
+    t.append_message(b"ephemeral-pk", ephemeral_pk.as_bytes());
+    t.append_message(b"recipient-pk", recipient_pk.as_bytes());
+    t.append_message(b"main-ciphertext", main_ciphertext_and_tag);
+
+    let mut key = [0u8; 32];
+    t.challenge_bytes(b"ovk-wrap-key", &mut key);
+    let cipher = ChaCha20Poly1305::new(GenericArray::from_slice(&key));
+    key.zeroize();
+    cipher
+}
+
+/// Parse and validate the ephemeral public key from the ciphertext header.
+fn parse_ephemeral_pk(
+    ephemeral_pk_bytes: &[u8],
+) -> Result<PublicKey, EciesError> {
+    let compressed = CompressedRistretto::from_slice(ephemeral_pk_bytes)
+        .map_err(|_| EciesError::InvalidEphemeralKey)?;
+    let point = compressed
+        .decompress()
+        .ok_or(EciesError::InvalidEphemeralKey)?;
+
+    if point == RistrettoPoint::default() {
+        return Err(EciesError::InvalidEphemeralKey);
+    }
+
+    Ok(PublicKey::from_point(point))
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt
+// ---------------------------------------------------------------------------
 
 /// Encrypt `plaintext` to `recipient` using ECIES over Ristretto255.
 ///
-/// The `ctx` parameter provides domain separation — use a unique
-/// application-specific byte string (e.g. `b"my-app-v1"`).
-///
-/// Returns the complete ciphertext including ephemeral public key,
-/// nonce, and authentication tag.
+/// - `ctx`: domain separation byte string (e.g. `b"my-app-v1"`).
+/// - `sender_ovk`: the sender's outgoing viewing key, embedded in the
+///   ciphertext so the sender can later re-read their own message.
 pub fn encrypt(
     plaintext: &[u8],
     recipient: &PublicKey,
     ctx: &[u8],
+    sender_ovk: &OutgoingViewingKey,
 ) -> Result<alloc::vec::Vec<u8>, EciesError> {
     let ephemeral = Keypair::generate();
-    encrypt_with(plaintext, recipient, ctx, &ephemeral.secret)
+    encrypt_with(plaintext, recipient, ctx, &ephemeral.secret, sender_ovk)
 }
 
-/// Encrypt `plaintext` to `recipient` using a caller-supplied ephemeral secret key.
+/// Encrypt with a caller-supplied ephemeral secret key.
 ///
-/// This is the deterministic core of [`encrypt`] — useful for testing
-/// or when the ephemeral key is derived externally.
+/// Deterministic core of [`encrypt`] — useful for testing or when the
+/// ephemeral key is derived externally.
 pub fn encrypt_with(
     plaintext: &[u8],
     recipient: &PublicKey,
     ctx: &[u8],
     ephemeral_secret: &SecretKey,
+    sender_ovk: &OutgoingViewingKey,
 ) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    reject_identity(recipient)?;
+
     let ephemeral_pk = ephemeral_secret.to_public();
 
     // ECDH
     let shared = ephemeral_secret.raw_key_exchange(recipient);
 
-    // Derive AEAD key
+    // Derive main AEAD
     let aead = derive_aead(
         &shared,
         ephemeral_pk.as_compressed(),
@@ -170,68 +279,108 @@ pub fn encrypt_with(
         ctx,
     );
 
-    // Generate nonce
+    // Random nonce
     let mut nonce_bytes = [0u8; NONCE_LEN];
     crate::getrandom_or_panic().fill_bytes(&mut nonce_bytes);
     let nonce = GenericArray::from_slice(&nonce_bytes);
 
-    // Build AAD: version || ephemeral_pk || recipient_pk
-    let mut aad = [0u8; 1 + PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH];
-    aad[0] = ECIES_VERSION;
-    aad[1..33].copy_from_slice(ephemeral_pk.as_compressed().as_bytes());
-    aad[33..65].copy_from_slice(recipient.as_compressed().as_bytes());
+    // AAD binds ephemeral pk and recipient pk
+    let aad = build_aad(ephemeral_pk.as_compressed(), recipient.as_compressed());
 
-    // Encrypt
+    // Encrypt plaintext
     let ciphertext_and_tag = aead
         .encrypt(nonce, chacha20poly1305::aead::Payload { msg: plaintext, aad: &aad })
-        .map_err(|_| EciesError::DecryptionFailed)?;
+        .map_err(|_| EciesError::EncryptionFailed)?;
 
-    // Assemble: version || ephemeral_pk || nonce || ciphertext_and_tag
+    // OVK-wrap the ephemeral secret scalar, binding to the main ciphertext
+    let ovk_aead = derive_ovk_wrap_aead(
+        sender_ovk.as_bytes(),
+        ephemeral_pk.as_compressed(),
+        recipient.as_compressed(),
+        &ciphertext_and_tag,
+    );
+
+    let mut ovk_nonce_bytes = [0u8; NONCE_LEN];
+    crate::getrandom_or_panic().fill_bytes(&mut ovk_nonce_bytes);
+    let ovk_nonce = GenericArray::from_slice(&ovk_nonce_bytes);
+
+    let mut esk_bytes = ephemeral_secret.key.to_bytes();
+    let ovk_ciphertext = ovk_aead
+        .encrypt(ovk_nonce, &esk_bytes[..])
+        .map_err(|_| EciesError::EncryptionFailed)?;
+    esk_bytes.zeroize();
+
+    // Assemble: ephemeral_pk || nonce || ciphertext+tag || ovk_nonce || ovk_ciphertext+tag
     let mut out = alloc::vec::Vec::with_capacity(ECIES_OVERHEAD + plaintext.len());
-    out.push(ECIES_VERSION);
     out.extend_from_slice(ephemeral_pk.as_compressed().as_bytes());
     out.extend_from_slice(&nonce_bytes);
     out.extend_from_slice(&ciphertext_and_tag);
+    out.extend_from_slice(&ovk_nonce_bytes);
+    out.extend_from_slice(&ovk_ciphertext);
     Ok(out)
 }
 
+// ---------------------------------------------------------------------------
+// Decrypt (recipient)
+// ---------------------------------------------------------------------------
+
 /// Decrypt an ECIES ciphertext using the recipient's secret key.
 ///
-/// The `ctx` must match the context used during [`encrypt`].
+/// The OVK blob is stripped and ignored.
 pub fn decrypt(
     ciphertext: &[u8],
     secret: &SecretKey,
+    ctx: &[u8],
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    let recipient_pk = secret.to_public();
+    decrypt_inner(
+        ciphertext,
+        |ephemeral_pk| secret.raw_key_exchange(ephemeral_pk),
+        &recipient_pk,
+        ctx,
+    )
+}
+
+/// Decrypt using an [`IncomingViewingKey`](crate::viewing_key::IncomingViewingKey).
+///
+/// The ciphertext must have been encrypted to the IVK's public key.
+pub fn decrypt_with_ivk(
+    ciphertext: &[u8],
+    ivk: &crate::viewing_key::IncomingViewingKey,
+    ctx: &[u8],
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    let recipient_pk = ivk.ivk_public();
+    decrypt_inner(
+        ciphertext,
+        |ephemeral_pk| ivk.raw_key_exchange(ephemeral_pk),
+        recipient_pk,
+        ctx,
+    )
+}
+
+/// Core decryption: parse header, ECDH, derive AEAD, decrypt payload.
+/// The OVK blob (last `OVK_BLOB_LEN` bytes) is stripped before decryption.
+fn decrypt_inner(
+    ciphertext: &[u8],
+    ecdh: impl FnOnce(&PublicKey) -> CompressedRistretto,
+    recipient_pk: &PublicKey,
     ctx: &[u8],
 ) -> Result<alloc::vec::Vec<u8>, EciesError> {
     if ciphertext.len() < ECIES_OVERHEAD {
         return Err(EciesError::CiphertextTooShort);
     }
 
-    // Parse header
-    let version = ciphertext[0];
-    if version != ECIES_VERSION {
-        return Err(EciesError::UnsupportedVersion { version });
-    }
+    let ephemeral_pk_bytes = &ciphertext[..PUBLIC_KEY_LENGTH];
+    let nonce_bytes = &ciphertext[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH + NONCE_LEN];
+    let main_end = ciphertext.len() - OVK_BLOB_LEN;
+    let encrypted = &ciphertext[PUBLIC_KEY_LENGTH + NONCE_LEN..main_end];
 
-    let ephemeral_pk_bytes = &ciphertext[1..1 + PUBLIC_KEY_LENGTH];
-    let nonce_bytes = &ciphertext[1 + PUBLIC_KEY_LENGTH..1 + PUBLIC_KEY_LENGTH + NONCE_LEN];
-    let encrypted = &ciphertext[1 + PUBLIC_KEY_LENGTH + NONCE_LEN..];
-
-    // Decompress ephemeral public key
-    let ephemeral_compressed = CompressedRistretto::from_slice(ephemeral_pk_bytes)
-        .map_err(|_| EciesError::InvalidEphemeralKey)?;
-    let ephemeral_point = ephemeral_compressed
-        .decompress()
-        .ok_or(EciesError::InvalidEphemeralKey)?;
-    let ephemeral_pk = PublicKey::from_point(ephemeral_point);
-
-    // Recipient public key
-    let recipient_pk = secret.to_public();
+    let ephemeral_pk = parse_ephemeral_pk(ephemeral_pk_bytes)?;
 
     // ECDH
-    let shared = secret.raw_key_exchange(&ephemeral_pk);
+    let shared = ecdh(&ephemeral_pk);
 
-    // Derive AEAD key
+    // Derive AEAD
     let aead_cipher = derive_aead(
         &shared,
         ephemeral_pk.as_compressed(),
@@ -239,18 +388,96 @@ pub fn decrypt(
         ctx,
     );
 
-    // Rebuild AAD
-    let mut aad = [0u8; 1 + PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH];
-    aad[0] = ECIES_VERSION;
-    aad[1..33].copy_from_slice(ephemeral_pk.as_compressed().as_bytes());
-    aad[33..65].copy_from_slice(recipient_pk.as_compressed().as_bytes());
-
-    // Decrypt
+    let aad = build_aad(ephemeral_pk.as_compressed(), recipient_pk.as_compressed());
     let nonce = GenericArray::from_slice(nonce_bytes);
     aead_cipher
         .decrypt(nonce, chacha20poly1305::aead::Payload { msg: encrypted, aad: &aad })
         .map_err(|_| EciesError::DecryptionFailed)
 }
+
+// ---------------------------------------------------------------------------
+// Decrypt (outgoing, via OVK)
+// ---------------------------------------------------------------------------
+
+/// Decrypt an outgoing ECIES ciphertext using an [`OutgoingViewingKey`].
+///
+/// Recovers the ephemeral secret from the OVK blob, re-derives the
+/// ECDH shared secret, and decrypts the main payload.
+pub fn decrypt_outgoing(
+    ciphertext: &[u8],
+    ovk: &OutgoingViewingKey,
+    recipient_pk: &PublicKey,
+    ctx: &[u8],
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    if ciphertext.len() < ECIES_OVERHEAD {
+        return Err(EciesError::CiphertextTooShort);
+    }
+
+    let ephemeral_pk_bytes = &ciphertext[..PUBLIC_KEY_LENGTH];
+    let nonce_bytes = &ciphertext[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH + NONCE_LEN];
+    let main_end = ciphertext.len() - OVK_BLOB_LEN;
+    let encrypted = &ciphertext[PUBLIC_KEY_LENGTH + NONCE_LEN..main_end];
+
+    // Parse OVK blob
+    let ovk_blob = &ciphertext[main_end..];
+    let ovk_nonce_bytes = &ovk_blob[..NONCE_LEN];
+    let ovk_ciphertext = &ovk_blob[NONCE_LEN..];
+
+    let ephemeral_pk = parse_ephemeral_pk(ephemeral_pk_bytes)?;
+
+    // Unwrap the ephemeral secret scalar, binding to the main ciphertext
+    let ovk_aead = derive_ovk_wrap_aead(
+        ovk.as_bytes(),
+        ephemeral_pk.as_compressed(),
+        recipient_pk.as_compressed(),
+        encrypted,
+    );
+
+    let ovk_nonce = GenericArray::from_slice(ovk_nonce_bytes);
+    let mut esk_bytes = ovk_aead
+        .decrypt(ovk_nonce, ovk_ciphertext)
+        .map_err(|_| EciesError::DecryptionFailed)?;
+
+    if esk_bytes.len() != SCALAR_LEN {
+        esk_bytes.zeroize();
+        return Err(EciesError::DecryptionFailed);
+    }
+
+    let mut scalar_arr = [0u8; 32];
+    scalar_arr.copy_from_slice(&esk_bytes);
+    esk_bytes.zeroize();
+
+    let mut esk_scalar = match crate::scalar_from_canonical_bytes(scalar_arr) {
+        Some(s) => s,
+        None => {
+            scalar_arr.zeroize();
+            return Err(EciesError::DecryptionFailed);
+        }
+    };
+    scalar_arr.zeroize();
+
+    // Re-derive ECDH shared secret: esk * recipient_pk
+    let shared = (esk_scalar * recipient_pk.as_point()).compress();
+    esk_scalar.zeroize();
+
+    // Derive main AEAD
+    let aead_cipher = derive_aead(
+        &shared,
+        ephemeral_pk.as_compressed(),
+        recipient_pk.as_compressed(),
+        ctx,
+    );
+
+    let aad = build_aad(ephemeral_pk.as_compressed(), recipient_pk.as_compressed());
+    let nonce = GenericArray::from_slice(nonce_bytes);
+    aead_cipher
+        .decrypt(nonce, chacha20poly1305::aead::Payload { msg: encrypted, aad: &aad })
+        .map_err(|_| EciesError::DecryptionFailed)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -263,101 +490,209 @@ mod tests {
         Keypair::generate_with(&mut rng)
     }
 
+    fn test_ovk(seed: u8) -> OutgoingViewingKey {
+        OutgoingViewingKey::from_secret(&test_keypair(seed).secret)
+    }
+
+    fn test_ivk(seed: u8) -> crate::viewing_key::IncomingViewingKey {
+        crate::viewing_key::IncomingViewingKey::from_secret(&test_keypair(seed).secret)
+    }
+
     #[test]
     fn round_trip() {
-        let alice = test_keypair(1);
-        let bob = test_keypair(2);
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
         let ctx = b"test-round-trip";
         let plaintext = b"hello bob, this is alice";
 
-        let encrypted = encrypt(plaintext, &bob.public, ctx).unwrap();
-        assert!(encrypted.len() == ECIES_OVERHEAD + plaintext.len());
+        let encrypted = encrypt(plaintext, bob_ivk.ivk_public(), ctx, &alice_ovk).unwrap();
+        assert_eq!(encrypted.len(), ECIES_OVERHEAD + plaintext.len());
 
-        let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
+        // Bob decrypts with IVK
+        let decrypted = bob_ivk.decrypt(&encrypted, ctx).unwrap();
         assert_eq!(&decrypted[..], plaintext);
 
-        // Alice cannot decrypt a message intended for Bob
-        let result = decrypt(&encrypted, &alice.secret, ctx);
-        assert_eq!(result, Err(EciesError::DecryptionFailed));
+        // Alice decrypts outgoing with OVK
+        let decrypted2 = decrypt_outgoing(&encrypted, &alice_ovk, bob_ivk.ivk_public(), ctx).unwrap();
+        assert_eq!(&decrypted2[..], plaintext);
+    }
+
+    #[test]
+    fn wrong_ivk_fails() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+        let charlie_ivk = test_ivk(3);
+
+        let encrypted = encrypt(b"secret", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        assert_eq!(
+            charlie_ivk.decrypt(&encrypted, b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn wrong_ovk_fails() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+        let charlie_ovk = test_ovk(3);
+
+        let encrypted = encrypt(b"secret", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        assert_eq!(
+            decrypt_outgoing(&encrypted, &charlie_ovk, bob_ivk.ivk_public(), b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn wrong_recipient_pk_in_outgoing_fails() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+        let charlie_ivk = test_ivk(3);
+
+        let encrypted = encrypt(b"test", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        // Wrong recipient pk → OVK wrap key mismatch
+        assert_eq!(
+            decrypt_outgoing(&encrypted, &alice_ovk, charlie_ivk.ivk_public(), b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
     }
 
     #[test]
     fn deterministic_encryption() {
-        let bob = test_keypair(2);
-        let ctx = b"test-deterministic";
-        let plaintext = b"deterministic test";
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+        let ctx = b"test-det";
+        let plaintext = b"deterministic";
 
-        let ephemeral = SecretKey::generate_with(ChaChaRng::from_seed([42; 32]));
-        let enc1 = encrypt_with(plaintext, &bob.public, ctx, &ephemeral).unwrap();
+        let eph = SecretKey::generate_with(ChaChaRng::from_seed([42; 32]));
+        let enc1 = encrypt_with(plaintext, bob_ivk.ivk_public(), ctx, &eph, &alice_ovk).unwrap();
+        let enc2 = encrypt_with(plaintext, bob_ivk.ivk_public(), ctx, &eph, &alice_ovk).unwrap();
 
-        // Same ephemeral key but different random nonce → different ciphertext
-        let enc2 = encrypt_with(plaintext, &bob.public, ctx, &ephemeral).unwrap();
-
-        // Ephemeral PK portion should be identical
-        assert_eq!(&enc1[..33], &enc2[..33]);
-        // But nonces differ so ciphertexts differ
+        // Same ephemeral pk
+        assert_eq!(&enc1[..32], &enc2[..32]);
+        // Different nonces
         assert_ne!(enc1, enc2);
 
-        // Both decrypt correctly
-        assert_eq!(decrypt(&enc1, &bob.secret, ctx).unwrap(), plaintext);
-        assert_eq!(decrypt(&enc2, &bob.secret, ctx).unwrap(), plaintext);
+        assert_eq!(bob_ivk.decrypt(&enc1, ctx).unwrap(), plaintext);
+        assert_eq!(bob_ivk.decrypt(&enc2, ctx).unwrap(), plaintext);
     }
 
     #[test]
     fn empty_plaintext() {
-        let bob = test_keypair(2);
-        let ctx = b"test-empty";
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
 
-        let encrypted = encrypt(b"", &bob.public, ctx).unwrap();
+        let encrypted = encrypt(b"", bob_ivk.ivk_public(), b"empty", &alice_ovk).unwrap();
         assert_eq!(encrypted.len(), ECIES_OVERHEAD);
-
-        let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
-        assert!(decrypted.is_empty());
+        assert!(bob_ivk.decrypt(&encrypted, b"empty").unwrap().is_empty());
+        assert!(
+            decrypt_outgoing(&encrypted, &alice_ovk, bob_ivk.ivk_public(), b"empty")
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
     fn wrong_context_fails() {
-        let bob = test_keypair(2);
-        let plaintext = b"context sensitive";
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
 
-        let encrypted = encrypt(plaintext, &bob.public, b"ctx-a").unwrap();
-        let result = decrypt(&encrypted, &bob.secret, b"ctx-b");
-        assert_eq!(result, Err(EciesError::DecryptionFailed));
+        let encrypted = encrypt(b"ctx test", bob_ivk.ivk_public(), b"ctx-a", &alice_ovk).unwrap();
+        assert_eq!(
+            bob_ivk.decrypt(&encrypted, b"ctx-b"),
+            Err(EciesError::DecryptionFailed)
+        );
     }
 
     #[test]
     fn truncated_ciphertext() {
-        let result = decrypt(&[0x01; 10], &test_keypair(1).secret, b"ctx");
-        assert_eq!(result, Err(EciesError::CiphertextTooShort));
-    }
-
-    #[test]
-    fn bad_version() {
-        let bob = test_keypair(2);
-        let mut encrypted = encrypt(b"test", &bob.public, b"ctx").unwrap();
-        encrypted[0] = 0xFF;
-        let result = decrypt(&encrypted, &bob.secret, b"ctx");
-        assert_eq!(result, Err(EciesError::UnsupportedVersion { version: 0xFF }));
+        assert_eq!(
+            decrypt(&[0u8; 10], &test_keypair(1).secret, b"ctx"),
+            Err(EciesError::CiphertextTooShort)
+        );
     }
 
     #[test]
     fn tampered_ciphertext() {
-        let bob = test_keypair(2);
-        let mut encrypted = encrypt(b"do not tamper", &bob.public, b"ctx").unwrap();
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let mut encrypted = encrypt(b"tamper", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        // Tamper in the main ciphertext area (before OVK blob)
+        let tamper_idx = PUBLIC_KEY_LENGTH + NONCE_LEN + 1;
+        encrypted[tamper_idx] ^= 0x01;
+        assert_eq!(
+            bob_ivk.decrypt(&encrypted, b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn tampered_ovk_blob() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let mut encrypted = encrypt(b"tamper ovk", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
         let last = encrypted.len() - 1;
         encrypted[last] ^= 0x01;
-        let result = decrypt(&encrypted, &bob.secret, b"ctx");
-        assert_eq!(result, Err(EciesError::DecryptionFailed));
+
+        // IVK decrypt still works (OVK blob is stripped)
+        assert!(bob_ivk.decrypt(&encrypted, b"ctx").is_ok());
+        // OVK decrypt fails
+        assert_eq!(
+            decrypt_outgoing(&encrypted, &alice_ovk, bob_ivk.ivk_public(), b"ctx"),
+            Err(EciesError::DecryptionFailed)
+        );
     }
 
     #[test]
     fn large_plaintext() {
-        let bob = test_keypair(2);
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
         let plaintext = alloc::vec![0xAB; 65536];
-        let ctx = b"large";
 
-        let encrypted = encrypt(&plaintext, &bob.public, ctx).unwrap();
+        let encrypted = encrypt(&plaintext, bob_ivk.ivk_public(), b"lg", &alice_ovk).unwrap();
+        assert_eq!(bob_ivk.decrypt(&encrypted, b"lg").unwrap(), plaintext);
+        assert_eq!(
+            decrypt_outgoing(&encrypted, &alice_ovk, bob_ivk.ivk_public(), b"lg").unwrap(),
+            plaintext
+        );
+    }
+
+    #[test]
+    fn reject_identity_recipient() {
+        let identity = PublicKey::from_bytes(&[0u8; 32]).unwrap();
+        let ovk = test_ovk(1);
+        assert_eq!(
+            encrypt(b"test", &identity, b"ctx", &ovk),
+            Err(EciesError::IdentityRecipient)
+        );
+    }
+
+    #[test]
+    fn reject_identity_ephemeral() {
+        let bob_ivk = test_ivk(2);
+        let alice_ovk = test_ovk(1);
+
+        let mut encrypted = encrypt(b"test", bob_ivk.ivk_public(), b"ctx", &alice_ovk).unwrap();
+        // Overwrite ephemeral pk with identity
+        encrypted[..32].copy_from_slice(&[0u8; 32]);
+        assert_eq!(
+            bob_ivk.decrypt(&encrypted, b"ctx"),
+            Err(EciesError::InvalidEphemeralKey)
+        );
+    }
+
+    #[test]
+    fn decrypt_with_secret_key_directly() {
+        // Encrypt to Bob's raw public key (not IVK), decrypt with secret key
+        let bob = test_keypair(2);
+        let alice_ovk = test_ovk(1);
+        let ctx = b"raw-sk";
+        let plaintext = b"direct secret key";
+
+        let encrypted = encrypt(plaintext, &bob.public, ctx, &alice_ovk).unwrap();
         let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
-        assert_eq!(decrypted, plaintext);
+        assert_eq!(&decrypted[..], plaintext);
     }
 }

--- a/src/ecies.rs
+++ b/src/ecies.rs
@@ -1,0 +1,363 @@
+// -*- mode: rust; -*-
+//
+// This file is part of schnorrkel.
+// Copyright (c) 2019 Web 3 Foundation
+// See LICENSE for licensing information.
+//
+// Authors:
+// - Jeff Burdges <jeff@web3.foundation>
+
+//! ## ECIES encryption using sr25519 keys
+//!
+//! Implements the Elliptic Curve Integrated Encryption Scheme (ECIES)
+//! over Ristretto255, providing high-level `encrypt` and `decrypt`
+//! operations using sr25519 keypairs.
+//!
+//! The scheme uses:
+//! - **Key agreement:** ECDH on Ristretto255 with ephemeral sender keys
+//! - **Key derivation:** Merlin transcript (STROBE128/Keccak-based)
+//! - **Symmetric cipher:** ChaCha20-Poly1305 (RFC 8439)
+//!
+//! ### Security properties
+//!
+//! - IND-CCA2 secure (ciphertext indistinguishability under adaptive chosen-ciphertext attack)
+//! - Forward secrecy against sender key compromise (ephemeral keys)
+//! - Authenticated encryption (Poly1305 tag)
+//! - Domain-separated key derivation via Merlin transcripts
+//!
+//! ### Wire format
+//!
+//! ```text
+//! [version: 1 byte] [ephemeral_pk: 32 bytes] [nonce: 12 bytes] [ciphertext + tag: N + 16 bytes]
+//! ```
+//!
+//! Total overhead: 61 bytes.
+//!
+//! ### Example
+//!
+//! ```
+//! # #[cfg(all(feature = "ecies", feature = "getrandom"))]
+//! # fn main() {
+//! use schnorrkel::Keypair;
+//! use schnorrkel::ecies;
+//!
+//! let alice = Keypair::generate();
+//! let bob = Keypair::generate();
+//!
+//! let plaintext = b"hidden message";
+//! let encrypted = ecies::encrypt(plaintext, &bob.public, b"my-app")
+//!     .expect("encryption failed");
+//!
+//! let decrypted = ecies::decrypt(&encrypted, &bob.secret, b"my-app")
+//!     .expect("decryption failed");
+//!
+//! assert_eq!(&decrypted, plaintext);
+//! # }
+//! # #[cfg(not(all(feature = "ecies", feature = "getrandom")))]
+//! # fn main() {}
+//! ```
+
+use rand_core::RngCore;
+
+use chacha20poly1305::{
+    ChaCha20Poly1305,
+    aead::{Aead, KeyInit, generic_array::GenericArray},
+};
+
+use curve25519_dalek::ristretto::CompressedRistretto;
+
+use crate::keys::{PublicKey, SecretKey, Keypair, PUBLIC_KEY_LENGTH};
+
+/// Current ECIES wire format version.
+const ECIES_VERSION: u8 = 0x01;
+
+/// Size of the ChaCha20-Poly1305 nonce (96 bits).
+const NONCE_LEN: usize = 12;
+
+/// Size of the Poly1305 authentication tag.
+const TAG_LEN: usize = 16;
+
+/// Fixed overhead added to every ECIES ciphertext:
+/// 1 (version) + 32 (ephemeral pubkey) + 12 (nonce) + 16 (auth tag).
+pub const ECIES_OVERHEAD: usize = 1 + PUBLIC_KEY_LENGTH + NONCE_LEN + TAG_LEN;
+
+/// Errors specific to ECIES encryption / decryption.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum EciesError {
+    /// The ciphertext is too short to contain the ECIES header and tag.
+    CiphertextTooShort,
+    /// Unsupported ECIES version byte.
+    UnsupportedVersion {
+        /// The version byte found in the ciphertext.
+        version: u8,
+    },
+    /// The ephemeral public key could not be decompressed.
+    InvalidEphemeralKey,
+    /// AEAD decryption failed (wrong key, corrupted data, or tampered ciphertext).
+    DecryptionFailed,
+}
+
+impl core::fmt::Display for EciesError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EciesError::CiphertextTooShort =>
+                write!(f, "ECIES ciphertext too short"),
+            EciesError::UnsupportedVersion { version } =>
+                write!(f, "Unsupported ECIES version: 0x{version:02x}"),
+            EciesError::InvalidEphemeralKey =>
+                write!(f, "Invalid ephemeral public key in ECIES ciphertext"),
+            EciesError::DecryptionFailed =>
+                write!(f, "ECIES decryption failed: authentication or key mismatch"),
+        }
+    }
+}
+
+/// Derive a ChaCha20-Poly1305 cipher from an ECDH shared secret,
+/// both public keys, and a context string, using a Merlin transcript.
+fn derive_aead(
+    shared_secret: &CompressedRistretto,
+    ephemeral_pk: &CompressedRistretto,
+    recipient_pk: &CompressedRistretto,
+    ctx: &[u8],
+) -> ChaCha20Poly1305 {
+    let mut t = merlin::Transcript::new(b"sr25519-ecies");
+    t.append_message(b"ctx", ctx);
+    t.append_message(b"ephemeral-pk", ephemeral_pk.as_bytes());
+    t.append_message(b"recipient-pk", recipient_pk.as_bytes());
+    t.append_message(b"shared-secret", shared_secret.as_bytes());
+
+    let mut key = [0u8; 32];
+    t.challenge_bytes(b"aead-key", &mut key);
+    ChaCha20Poly1305::new(GenericArray::from_slice(&key))
+}
+
+/// Encrypt `plaintext` to `recipient` using ECIES over Ristretto255.
+///
+/// The `ctx` parameter provides domain separation — use a unique
+/// application-specific byte string (e.g. `b"my-app-v1"`).
+///
+/// Returns the complete ciphertext including ephemeral public key,
+/// nonce, and authentication tag.
+pub fn encrypt(
+    plaintext: &[u8],
+    recipient: &PublicKey,
+    ctx: &[u8],
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    let ephemeral = Keypair::generate();
+    encrypt_with(plaintext, recipient, ctx, &ephemeral.secret)
+}
+
+/// Encrypt `plaintext` to `recipient` using a caller-supplied ephemeral secret key.
+///
+/// This is the deterministic core of [`encrypt`] — useful for testing
+/// or when the ephemeral key is derived externally.
+pub fn encrypt_with(
+    plaintext: &[u8],
+    recipient: &PublicKey,
+    ctx: &[u8],
+    ephemeral_secret: &SecretKey,
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    let ephemeral_pk = ephemeral_secret.to_public();
+
+    // ECDH
+    let shared = ephemeral_secret.raw_key_exchange(recipient);
+
+    // Derive AEAD key
+    let aead = derive_aead(
+        &shared,
+        ephemeral_pk.as_compressed(),
+        recipient.as_compressed(),
+        ctx,
+    );
+
+    // Generate nonce
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    crate::getrandom_or_panic().fill_bytes(&mut nonce_bytes);
+    let nonce = GenericArray::from_slice(&nonce_bytes);
+
+    // Build AAD: version || ephemeral_pk || recipient_pk
+    let mut aad = [0u8; 1 + PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH];
+    aad[0] = ECIES_VERSION;
+    aad[1..33].copy_from_slice(ephemeral_pk.as_compressed().as_bytes());
+    aad[33..65].copy_from_slice(recipient.as_compressed().as_bytes());
+
+    // Encrypt
+    let ciphertext_and_tag = aead
+        .encrypt(nonce, chacha20poly1305::aead::Payload { msg: plaintext, aad: &aad })
+        .map_err(|_| EciesError::DecryptionFailed)?;
+
+    // Assemble: version || ephemeral_pk || nonce || ciphertext_and_tag
+    let mut out = alloc::vec::Vec::with_capacity(ECIES_OVERHEAD + plaintext.len());
+    out.push(ECIES_VERSION);
+    out.extend_from_slice(ephemeral_pk.as_compressed().as_bytes());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext_and_tag);
+    Ok(out)
+}
+
+/// Decrypt an ECIES ciphertext using the recipient's secret key.
+///
+/// The `ctx` must match the context used during [`encrypt`].
+pub fn decrypt(
+    ciphertext: &[u8],
+    secret: &SecretKey,
+    ctx: &[u8],
+) -> Result<alloc::vec::Vec<u8>, EciesError> {
+    if ciphertext.len() < ECIES_OVERHEAD {
+        return Err(EciesError::CiphertextTooShort);
+    }
+
+    // Parse header
+    let version = ciphertext[0];
+    if version != ECIES_VERSION {
+        return Err(EciesError::UnsupportedVersion { version });
+    }
+
+    let ephemeral_pk_bytes = &ciphertext[1..1 + PUBLIC_KEY_LENGTH];
+    let nonce_bytes = &ciphertext[1 + PUBLIC_KEY_LENGTH..1 + PUBLIC_KEY_LENGTH + NONCE_LEN];
+    let encrypted = &ciphertext[1 + PUBLIC_KEY_LENGTH + NONCE_LEN..];
+
+    // Decompress ephemeral public key
+    let ephemeral_compressed = CompressedRistretto::from_slice(ephemeral_pk_bytes)
+        .map_err(|_| EciesError::InvalidEphemeralKey)?;
+    let ephemeral_point = ephemeral_compressed
+        .decompress()
+        .ok_or(EciesError::InvalidEphemeralKey)?;
+    let ephemeral_pk = PublicKey::from_point(ephemeral_point);
+
+    // Recipient public key
+    let recipient_pk = secret.to_public();
+
+    // ECDH
+    let shared = secret.raw_key_exchange(&ephemeral_pk);
+
+    // Derive AEAD key
+    let aead_cipher = derive_aead(
+        &shared,
+        ephemeral_pk.as_compressed(),
+        recipient_pk.as_compressed(),
+        ctx,
+    );
+
+    // Rebuild AAD
+    let mut aad = [0u8; 1 + PUBLIC_KEY_LENGTH + PUBLIC_KEY_LENGTH];
+    aad[0] = ECIES_VERSION;
+    aad[1..33].copy_from_slice(ephemeral_pk.as_compressed().as_bytes());
+    aad[33..65].copy_from_slice(recipient_pk.as_compressed().as_bytes());
+
+    // Decrypt
+    let nonce = GenericArray::from_slice(nonce_bytes);
+    aead_cipher
+        .decrypt(nonce, chacha20poly1305::aead::Payload { msg: encrypted, aad: &aad })
+        .map_err(|_| EciesError::DecryptionFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
+
+    fn test_keypair(seed: u8) -> Keypair {
+        let mut rng = ChaChaRng::from_seed([seed; 32]);
+        Keypair::generate_with(&mut rng)
+    }
+
+    #[test]
+    fn round_trip() {
+        let alice = test_keypair(1);
+        let bob = test_keypair(2);
+        let ctx = b"test-round-trip";
+        let plaintext = b"hello bob, this is alice";
+
+        let encrypted = encrypt(plaintext, &bob.public, ctx).unwrap();
+        assert!(encrypted.len() == ECIES_OVERHEAD + plaintext.len());
+
+        let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
+        assert_eq!(&decrypted[..], plaintext);
+
+        // Alice cannot decrypt a message intended for Bob
+        let result = decrypt(&encrypted, &alice.secret, ctx);
+        assert_eq!(result, Err(EciesError::DecryptionFailed));
+    }
+
+    #[test]
+    fn deterministic_encryption() {
+        let bob = test_keypair(2);
+        let ctx = b"test-deterministic";
+        let plaintext = b"deterministic test";
+
+        let ephemeral = SecretKey::generate_with(ChaChaRng::from_seed([42; 32]));
+        let enc1 = encrypt_with(plaintext, &bob.public, ctx, &ephemeral).unwrap();
+
+        // Same ephemeral key but different random nonce → different ciphertext
+        let enc2 = encrypt_with(plaintext, &bob.public, ctx, &ephemeral).unwrap();
+
+        // Ephemeral PK portion should be identical
+        assert_eq!(&enc1[..33], &enc2[..33]);
+        // But nonces differ so ciphertexts differ
+        assert_ne!(enc1, enc2);
+
+        // Both decrypt correctly
+        assert_eq!(decrypt(&enc1, &bob.secret, ctx).unwrap(), plaintext);
+        assert_eq!(decrypt(&enc2, &bob.secret, ctx).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn empty_plaintext() {
+        let bob = test_keypair(2);
+        let ctx = b"test-empty";
+
+        let encrypted = encrypt(b"", &bob.public, ctx).unwrap();
+        assert_eq!(encrypted.len(), ECIES_OVERHEAD);
+
+        let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
+        assert!(decrypted.is_empty());
+    }
+
+    #[test]
+    fn wrong_context_fails() {
+        let bob = test_keypair(2);
+        let plaintext = b"context sensitive";
+
+        let encrypted = encrypt(plaintext, &bob.public, b"ctx-a").unwrap();
+        let result = decrypt(&encrypted, &bob.secret, b"ctx-b");
+        assert_eq!(result, Err(EciesError::DecryptionFailed));
+    }
+
+    #[test]
+    fn truncated_ciphertext() {
+        let result = decrypt(&[0x01; 10], &test_keypair(1).secret, b"ctx");
+        assert_eq!(result, Err(EciesError::CiphertextTooShort));
+    }
+
+    #[test]
+    fn bad_version() {
+        let bob = test_keypair(2);
+        let mut encrypted = encrypt(b"test", &bob.public, b"ctx").unwrap();
+        encrypted[0] = 0xFF;
+        let result = decrypt(&encrypted, &bob.secret, b"ctx");
+        assert_eq!(result, Err(EciesError::UnsupportedVersion { version: 0xFF }));
+    }
+
+    #[test]
+    fn tampered_ciphertext() {
+        let bob = test_keypair(2);
+        let mut encrypted = encrypt(b"do not tamper", &bob.public, b"ctx").unwrap();
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 0x01;
+        let result = decrypt(&encrypted, &bob.secret, b"ctx");
+        assert_eq!(result, Err(EciesError::DecryptionFailed));
+    }
+
+    #[test]
+    fn large_plaintext() {
+        let bob = test_keypair(2);
+        let plaintext = alloc::vec![0xAB; 65536];
+        let ctx = b"large";
+
+        let encrypted = encrypt(&plaintext, &bob.public, ctx).unwrap();
+        let decrypted = decrypt(&encrypted, &bob.secret, ctx).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,9 @@ pub mod aead;
 #[cfg(all(feature = "ecies", feature = "getrandom"))]
 pub mod ecies;
 
+#[cfg(all(feature = "ecies", feature = "getrandom"))]
+pub mod viewing_key;
+
 #[cfg(feature = "alloc")]
 mod batch;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,9 @@ pub mod errors;
 #[cfg(all(feature = "aead", feature = "getrandom"))]
 pub mod aead;
 
+#[cfg(all(feature = "ecies", feature = "getrandom"))]
+pub mod ecies;
+
 #[cfg(feature = "alloc")]
 mod batch;
 

--- a/src/viewing_key.rs
+++ b/src/viewing_key.rs
@@ -1,0 +1,678 @@
+// -*- mode: rust; -*-
+//
+// This file is part of schnorrkel.
+// Copyright (c) 2019 Web 3 Foundation
+// See LICENSE for licensing information.
+//
+// Authors:
+// - Jeff Burdges <jeff@web3.foundation>
+
+//! ## Full viewing keys for sr25519
+//!
+//! A Penumbra-style viewing key hierarchy that separates
+//! incoming decryption, outgoing decryption, and signing authority.
+//!
+//! ```text
+//! SecretKey
+//!   ├── FullViewingKey { ivk, ovk, signing_public }
+//!   │   ├── IncomingViewingKey   ← decrypt messages TO you
+//!   │   └── OutgoingViewingKey   ← decrypt messages BY you
+//!   └── sign()                   ← spending, full secret only
+//! ```
+//!
+//! All derivations are one-way via domain-separated Merlin transcripts:
+//!
+//! ```text
+//! ivk_scalar = Merlin("sr25519-ivk", signing_scalar)   → ECDH scalar
+//! ovk        = Merlin("sr25519-ovk", signing_scalar)   → 32-byte symmetric key
+//! ```
+//!
+//! ### Example
+//!
+//! ```
+//! # #[cfg(all(feature = "ecies", feature = "getrandom"))]
+//! # fn main() {
+//! use schnorrkel::{Keypair, ecies};
+//! use schnorrkel::viewing_key::FullViewingKey;
+//!
+//! let alice = Keypair::generate();
+//! let bob = Keypair::generate();
+//! let bob_fvk = FullViewingKey::from_keypair(&bob);
+//!
+//! // Alice encrypts to Bob's incoming viewing public key,
+//! // attaching her OVK so she can later re-read her own message.
+//! let alice_fvk = FullViewingKey::from_keypair(&alice);
+//! let plaintext = b"confidential data";
+//! let encrypted = ecies::encrypt(
+//!     plaintext, bob_fvk.ivk_public(), b"my-app",
+//!     alice_fvk.ovk(),
+//! ).expect("encryption failed");
+//!
+//! // Bob decrypts with his IVK
+//! let decrypted = bob_fvk.decrypt_incoming(&encrypted, b"my-app")
+//!     .expect("decryption failed");
+//! assert_eq!(&decrypted, plaintext);
+//!
+//! // Alice re-reads her own outgoing message via OVK
+//! let decrypted2 = alice_fvk.decrypt_outgoing(
+//!     &encrypted, bob_fvk.ivk_public(), b"my-app",
+//! ).expect("outgoing decryption failed");
+//! assert_eq!(&decrypted2, plaintext);
+//! # }
+//! # #[cfg(not(all(feature = "ecies", feature = "getrandom")))]
+//! # fn main() {}
+//! ```
+
+use core::fmt::Debug;
+
+use curve25519_dalek::constants;
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::scalar::Scalar;
+
+use subtle::{ConstantTimeEq, Choice};
+use zeroize::Zeroize;
+
+use crate::keys::{PublicKey, SecretKey, PUBLIC_KEY_LENGTH};
+use crate::errors::{SignatureError, SignatureResult};
+
+// ---------------------------------------------------------------------------
+// IncomingViewingKey
+// ---------------------------------------------------------------------------
+
+/// Length of a serialized [`IncomingViewingKey`]: 32 (scalar) + 32 (public).
+pub const INCOMING_VIEWING_KEY_LENGTH: usize = 32 + PUBLIC_KEY_LENGTH;
+
+/// An incoming viewing key derived one-way from an sr25519 secret key.
+///
+/// Allows decryption of ECIES messages encrypted to [`ivk_public`](Self::ivk_public)
+/// but cannot produce signatures.
+#[derive(Clone)]
+pub struct IncomingViewingKey {
+    /// The incoming viewing scalar.
+    pub(crate) ivk_scalar: Scalar,
+    /// The incoming viewing public key: `ivk_scalar * G`.
+    pub(crate) ivk_public: PublicKey,
+}
+
+impl Debug for IncomingViewingKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "IncomingViewingKey {{ ivk_public: {:?} }}", self.ivk_public)
+    }
+}
+
+impl Eq for IncomingViewingKey {}
+impl PartialEq for IncomingViewingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
+    }
+}
+impl ConstantTimeEq for IncomingViewingKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.ivk_scalar.ct_eq(&other.ivk_scalar)
+    }
+}
+
+impl Zeroize for IncomingViewingKey {
+    fn zeroize(&mut self) {
+        self.ivk_scalar.zeroize();
+    }
+}
+impl Drop for IncomingViewingKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl IncomingViewingKey {
+    /// Derive an `IncomingViewingKey` from a secret key.
+    pub fn from_secret(secret: &SecretKey) -> Self {
+        let ivk_scalar = Self::derive_scalar(secret);
+        let ivk_public =
+            PublicKey::from_point(&ivk_scalar * constants::RISTRETTO_BASEPOINT_TABLE);
+        IncomingViewingKey { ivk_scalar, ivk_public }
+    }
+
+    /// One-way scalar derivation via Merlin transcript.
+    fn derive_scalar(secret: &SecretKey) -> Scalar {
+        let mut t = merlin::Transcript::new(b"sr25519-ivk");
+        t.append_message(b"signing-scalar", &secret.key.to_bytes());
+        let mut buf = [0u8; 64];
+        t.challenge_bytes(b"ivk-scalar", &mut buf);
+        let scalar = Scalar::from_bytes_mod_order_wide(&buf);
+        buf.zeroize();
+        scalar
+    }
+
+    /// The public key that senders should encrypt to.
+    pub fn ivk_public(&self) -> &PublicKey {
+        &self.ivk_public
+    }
+
+    /// Perform ECDH using the incoming viewing scalar.
+    pub(crate) fn raw_key_exchange(&self, public: &PublicKey) -> CompressedRistretto {
+        (self.ivk_scalar * public.as_point()).compress()
+    }
+
+    /// Decrypt an ECIES ciphertext encrypted to this key's
+    /// [`ivk_public`](Self::ivk_public).
+    #[cfg(feature = "ecies")]
+    pub fn decrypt(
+        &self,
+        ciphertext: &[u8],
+        ctx: &[u8],
+    ) -> Result<alloc::vec::Vec<u8>, crate::ecies::EciesError> {
+        crate::ecies::decrypt_with_ivk(ciphertext, self, ctx)
+    }
+
+    /// Serialize to bytes: `[ivk_scalar: 32] [ivk_public: 32]`.
+    pub fn to_bytes(&self) -> [u8; INCOMING_VIEWING_KEY_LENGTH] {
+        let mut bytes = [0u8; INCOMING_VIEWING_KEY_LENGTH];
+        bytes[..32].copy_from_slice(&self.ivk_scalar.to_bytes());
+        bytes[32..64].copy_from_slice(&self.ivk_public.to_bytes());
+        bytes
+    }
+
+    /// Deserialize, verifying `ivk_scalar * G == ivk_public`.
+    pub fn from_bytes(bytes: &[u8]) -> SignatureResult<Self> {
+        if bytes.len() != INCOMING_VIEWING_KEY_LENGTH {
+            return Err(SignatureError::BytesLengthError {
+                name: "IncomingViewingKey",
+                description: "A 64-byte sr25519 incoming viewing key",
+                length: INCOMING_VIEWING_KEY_LENGTH,
+            });
+        }
+
+        let mut scalar_bytes = [0u8; 32];
+        scalar_bytes.copy_from_slice(&bytes[..32]);
+        let ivk_scalar = crate::scalar_from_canonical_bytes(scalar_bytes)
+            .ok_or(SignatureError::ScalarFormatError)?;
+
+        let ivk_public = PublicKey::from_bytes(&bytes[32..64])?;
+
+        let expected =
+            PublicKey::from_point(&ivk_scalar * constants::RISTRETTO_BASEPOINT_TABLE);
+        if expected != ivk_public {
+            return Err(SignatureError::PointDecompressionError);
+        }
+
+        Ok(IncomingViewingKey { ivk_scalar, ivk_public })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OutgoingViewingKey
+// ---------------------------------------------------------------------------
+
+/// Length of a serialized [`OutgoingViewingKey`]: 32 bytes (symmetric key).
+pub const OUTGOING_VIEWING_KEY_LENGTH: usize = 32;
+
+/// An outgoing viewing key derived one-way from an sr25519 secret key.
+///
+/// This 32-byte symmetric key is used to wrap the ephemeral secret
+/// inside ECIES ciphertexts, allowing the sender to later re-derive
+/// the shared secret and decrypt their own outgoing messages.
+#[derive(Clone)]
+pub struct OutgoingViewingKey {
+    /// The 32-byte symmetric OVK.
+    pub(crate) ovk: [u8; 32],
+}
+
+impl Debug for OutgoingViewingKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "OutgoingViewingKey(***)")
+    }
+}
+
+impl Eq for OutgoingViewingKey {}
+impl PartialEq for OutgoingViewingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
+    }
+}
+impl ConstantTimeEq for OutgoingViewingKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.ovk.ct_eq(&other.ovk)
+    }
+}
+
+impl Zeroize for OutgoingViewingKey {
+    fn zeroize(&mut self) {
+        self.ovk.zeroize();
+    }
+}
+impl Drop for OutgoingViewingKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl OutgoingViewingKey {
+    /// Derive an `OutgoingViewingKey` from a secret key.
+    pub fn from_secret(secret: &SecretKey) -> Self {
+        let mut t = merlin::Transcript::new(b"sr25519-ovk");
+        t.append_message(b"signing-scalar", &secret.key.to_bytes());
+        let mut ovk = [0u8; 32];
+        t.challenge_bytes(b"ovk-key", &mut ovk);
+        OutgoingViewingKey { ovk }
+    }
+
+    /// Access the raw 32-byte OVK material.
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.ovk
+    }
+
+    /// Serialize to 32 bytes.
+    pub fn to_bytes(&self) -> [u8; OUTGOING_VIEWING_KEY_LENGTH] {
+        self.ovk
+    }
+
+    /// Deserialize from 32 bytes.
+    pub fn from_bytes(bytes: &[u8]) -> SignatureResult<Self> {
+        if bytes.len() != OUTGOING_VIEWING_KEY_LENGTH {
+            return Err(SignatureError::BytesLengthError {
+                name: "OutgoingViewingKey",
+                description: "A 32-byte sr25519 outgoing viewing key",
+                length: OUTGOING_VIEWING_KEY_LENGTH,
+            });
+        }
+        let mut ovk = [0u8; 32];
+        ovk.copy_from_slice(bytes);
+        Ok(OutgoingViewingKey { ovk })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FullViewingKey
+// ---------------------------------------------------------------------------
+
+/// Length of a serialized [`FullViewingKey`]:
+/// 32 (ivk scalar) + 32 (ivk public) + 32 (ovk) + 32 (signing public) = 128.
+pub const FULL_VIEWING_KEY_LENGTH: usize =
+    INCOMING_VIEWING_KEY_LENGTH + OUTGOING_VIEWING_KEY_LENGTH + PUBLIC_KEY_LENGTH;
+
+/// A full viewing key that bundles incoming and outgoing viewing
+/// capabilities with the signing public key for identification.
+///
+/// Derived one-way from a [`SecretKey`]; cannot produce signatures.
+#[derive(Clone)]
+pub struct FullViewingKey {
+    /// Incoming viewing key.
+    ivk: IncomingViewingKey,
+    /// Outgoing viewing key.
+    ovk: OutgoingViewingKey,
+    /// The original signing public key (advisory — not cryptographically
+    /// bound to the IVK/OVK, only trustworthy if you derived this FVK
+    /// yourself).
+    signing_public: PublicKey,
+}
+
+impl Debug for FullViewingKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "FullViewingKey {{ ivk_public: {:?}, signing_public: {:?} }}",
+            self.ivk.ivk_public, self.signing_public
+        )
+    }
+}
+
+impl Eq for FullViewingKey {}
+impl PartialEq for FullViewingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
+    }
+}
+impl ConstantTimeEq for FullViewingKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.ivk.ct_eq(&other.ivk) & self.ovk.ct_eq(&other.ovk)
+    }
+}
+
+impl Zeroize for FullViewingKey {
+    fn zeroize(&mut self) {
+        self.ivk.zeroize();
+        self.ovk.zeroize();
+    }
+}
+impl Drop for FullViewingKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl FullViewingKey {
+    /// Derive a `FullViewingKey` from a [`SecretKey`].
+    pub fn from_secret(secret: &SecretKey) -> Self {
+        let ivk = IncomingViewingKey::from_secret(secret);
+        let ovk = OutgoingViewingKey::from_secret(secret);
+        let signing_public = secret.to_public();
+        FullViewingKey { ivk, ovk, signing_public }
+    }
+
+    /// Derive a `FullViewingKey` from a [`Keypair`](crate::Keypair)
+    /// (avoids recomputing the signing public key).
+    pub fn from_keypair(keypair: &crate::Keypair) -> Self {
+        let ivk = IncomingViewingKey::from_secret(&keypair.secret);
+        let ovk = OutgoingViewingKey::from_secret(&keypair.secret);
+        FullViewingKey {
+            ivk,
+            ovk,
+            signing_public: keypair.public,
+        }
+    }
+
+    /// The incoming viewing key.
+    pub fn ivk(&self) -> &IncomingViewingKey {
+        &self.ivk
+    }
+
+    /// The outgoing viewing key.
+    pub fn ovk(&self) -> &OutgoingViewingKey {
+        &self.ovk
+    }
+
+    /// Shortcut: the IVK's public key (what senders encrypt to).
+    pub fn ivk_public(&self) -> &PublicKey {
+        self.ivk.ivk_public()
+    }
+
+    /// The original signing public key (advisory).
+    pub fn signing_public(&self) -> &PublicKey {
+        &self.signing_public
+    }
+
+    /// Decrypt an incoming ECIES message.
+    #[cfg(feature = "ecies")]
+    pub fn decrypt_incoming(
+        &self,
+        ciphertext: &[u8],
+        ctx: &[u8],
+    ) -> Result<alloc::vec::Vec<u8>, crate::ecies::EciesError> {
+        self.ivk.decrypt(ciphertext, ctx)
+    }
+
+    /// Decrypt an outgoing ECIES message using the OVK.
+    ///
+    /// `recipient_pk` is the IVK public key of the recipient
+    /// (needed to re-derive the OVK-wrap AEAD key).
+    #[cfg(feature = "ecies")]
+    pub fn decrypt_outgoing(
+        &self,
+        ciphertext: &[u8],
+        recipient_pk: &PublicKey,
+        ctx: &[u8],
+    ) -> Result<alloc::vec::Vec<u8>, crate::ecies::EciesError> {
+        crate::ecies::decrypt_outgoing(ciphertext, &self.ovk, recipient_pk, ctx)
+    }
+
+    /// Serialize: `[ivk_scalar: 32] [ivk_public: 32] [ovk: 32] [signing_public: 32]`.
+    pub fn to_bytes(&self) -> [u8; FULL_VIEWING_KEY_LENGTH] {
+        let mut bytes = [0u8; FULL_VIEWING_KEY_LENGTH];
+        let ivk_bytes = self.ivk.to_bytes();
+        bytes[..64].copy_from_slice(&ivk_bytes);
+        bytes[64..96].copy_from_slice(&self.ovk.to_bytes());
+        bytes[96..128].copy_from_slice(&self.signing_public.to_bytes());
+        bytes
+    }
+
+    /// Deserialize, verifying IVK consistency.
+    pub fn from_bytes(bytes: &[u8]) -> SignatureResult<Self> {
+        if bytes.len() != FULL_VIEWING_KEY_LENGTH {
+            return Err(SignatureError::BytesLengthError {
+                name: "FullViewingKey",
+                description: "A 128-byte sr25519 full viewing key",
+                length: FULL_VIEWING_KEY_LENGTH,
+            });
+        }
+
+        let ivk = IncomingViewingKey::from_bytes(&bytes[..64])?;
+        let ovk = OutgoingViewingKey::from_bytes(&bytes[64..96])?;
+        let signing_public = PublicKey::from_bytes(&bytes[96..128])?;
+
+        Ok(FullViewingKey { ivk, ovk, signing_public })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Keypair;
+    use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
+
+    fn test_keypair(seed: u8) -> Keypair {
+        let mut rng = ChaChaRng::from_seed([seed; 32]);
+        Keypair::generate_with(&mut rng)
+    }
+
+    // --- IncomingViewingKey tests ---
+
+    #[test]
+    fn ivk_derivation_is_deterministic() {
+        let kp = test_keypair(1);
+        let ivk1 = IncomingViewingKey::from_secret(&kp.secret);
+        let ivk2 = IncomingViewingKey::from_secret(&kp.secret);
+        assert_eq!(ivk1, ivk2);
+    }
+
+    #[test]
+    fn ivk_public_differs_from_signing_public() {
+        let kp = test_keypair(1);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        assert_ne!(ivk.ivk_public(), &kp.public);
+    }
+
+    #[test]
+    fn ivk_different_keys_differ() {
+        let ivk1 = IncomingViewingKey::from_secret(&test_keypair(1).secret);
+        let ivk2 = IncomingViewingKey::from_secret(&test_keypair(2).secret);
+        assert_ne!(ivk1, ivk2);
+    }
+
+    #[test]
+    fn ivk_serialization_round_trip() {
+        let kp = test_keypair(1);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        let bytes = ivk.to_bytes();
+        let ivk2 = IncomingViewingKey::from_bytes(&bytes).unwrap();
+        assert_eq!(ivk, ivk2);
+    }
+
+    #[test]
+    fn ivk_tampered_scalar_rejected() {
+        let kp = test_keypair(1);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        let mut bytes = ivk.to_bytes();
+        bytes[0] ^= 0x01;
+        assert!(IncomingViewingKey::from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn ivk_debug_does_not_leak_scalar() {
+        let kp = test_keypair(1);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        let debug = alloc::format!("{:?}", ivk);
+        assert!(!debug.contains("ivk_scalar"));
+    }
+
+    // --- OutgoingViewingKey tests ---
+
+    #[test]
+    fn ovk_derivation_is_deterministic() {
+        let kp = test_keypair(1);
+        let ovk1 = OutgoingViewingKey::from_secret(&kp.secret);
+        let ovk2 = OutgoingViewingKey::from_secret(&kp.secret);
+        assert_eq!(ovk1, ovk2);
+    }
+
+    #[test]
+    fn ovk_different_keys_differ() {
+        let ovk1 = OutgoingViewingKey::from_secret(&test_keypair(1).secret);
+        let ovk2 = OutgoingViewingKey::from_secret(&test_keypair(2).secret);
+        assert_ne!(ovk1, ovk2);
+    }
+
+    #[test]
+    fn ovk_serialization_round_trip() {
+        let kp = test_keypair(1);
+        let ovk = OutgoingViewingKey::from_secret(&kp.secret);
+        let bytes = ovk.to_bytes();
+        let ovk2 = OutgoingViewingKey::from_bytes(&bytes).unwrap();
+        assert_eq!(ovk, ovk2);
+    }
+
+    #[test]
+    fn ovk_debug_redacted() {
+        let kp = test_keypair(1);
+        let ovk = OutgoingViewingKey::from_secret(&kp.secret);
+        let debug = alloc::format!("{:?}", ovk);
+        assert_eq!(debug, "OutgoingViewingKey(***)");
+    }
+
+    // --- FullViewingKey tests ---
+
+    #[test]
+    fn fvk_from_secret_and_keypair_match() {
+        let kp = test_keypair(1);
+        let fvk1 = FullViewingKey::from_secret(&kp.secret);
+        let fvk2 = FullViewingKey::from_keypair(&kp);
+        assert_eq!(fvk1.ivk, fvk2.ivk);
+        assert_eq!(fvk1.ovk, fvk2.ovk);
+        assert_eq!(fvk1.signing_public, fvk2.signing_public);
+    }
+
+    #[test]
+    fn fvk_serialization_round_trip() {
+        let kp = test_keypair(1);
+        let fvk = FullViewingKey::from_keypair(&kp);
+        let bytes = fvk.to_bytes();
+        assert_eq!(bytes.len(), FULL_VIEWING_KEY_LENGTH);
+        let fvk2 = FullViewingKey::from_bytes(&bytes).unwrap();
+        assert_eq!(fvk, fvk2);
+    }
+
+    #[test]
+    fn fvk_debug_does_not_leak_secrets() {
+        let kp = test_keypair(1);
+        let fvk = FullViewingKey::from_keypair(&kp);
+        let debug = alloc::format!("{:?}", fvk);
+        let ivk_hex = alloc::format!("{:?}", fvk.ivk.ivk_scalar.to_bytes());
+        assert!(!debug.contains(&ivk_hex));
+    }
+
+    #[test]
+    fn ivk_and_ovk_are_independent() {
+        // IVK is a scalar, OVK is a symmetric key — derived from the
+        // same secret via different domain tags, they must differ.
+        let kp = test_keypair(1);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        let ovk = OutgoingViewingKey::from_secret(&kp.secret);
+        assert_ne!(&ivk.ivk_scalar.to_bytes()[..], &ovk.ovk[..]);
+    }
+
+    // --- ECIES integration tests ---
+
+    #[cfg(feature = "ecies")]
+    #[test]
+    fn ecies_ivk_round_trip() {
+        let kp = test_keypair(1);
+        let alice_ovk = OutgoingViewingKey::from_secret(&test_keypair(2).secret);
+        let ivk = IncomingViewingKey::from_secret(&kp.secret);
+        let ctx = b"test-ivk";
+        let plaintext = b"incoming only";
+
+        let encrypted =
+            crate::ecies::encrypt(plaintext, ivk.ivk_public(), ctx, &alice_ovk).unwrap();
+
+        let decrypted = ivk.decrypt(&encrypted, ctx).unwrap();
+        assert_eq!(&decrypted[..], plaintext);
+
+        // Signing secret key cannot decrypt (different key)
+        let result = crate::ecies::decrypt(&encrypted, &kp.secret, ctx);
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "ecies")]
+    #[test]
+    fn ecies_fvk_round_trip() {
+        let alice = test_keypair(1);
+        let bob = test_keypair(2);
+        let alice_fvk = FullViewingKey::from_keypair(&alice);
+        let bob_fvk = FullViewingKey::from_keypair(&bob);
+        let ctx = b"test-fvk";
+        let plaintext = b"full viewing key round trip";
+
+        let encrypted = crate::ecies::encrypt(
+            plaintext,
+            bob_fvk.ivk_public(),
+            ctx,
+            alice_fvk.ovk(),
+        )
+        .unwrap();
+
+        // Bob decrypts incoming
+        let decrypted = bob_fvk.decrypt_incoming(&encrypted, ctx).unwrap();
+        assert_eq!(&decrypted[..], plaintext);
+
+        // Alice decrypts outgoing
+        let decrypted2 = alice_fvk
+            .decrypt_outgoing(&encrypted, bob_fvk.ivk_public(), ctx)
+            .unwrap();
+        assert_eq!(&decrypted2[..], plaintext);
+    }
+
+    #[cfg(feature = "ecies")]
+    #[test]
+    fn wrong_ovk_fails() {
+        let alice = test_keypair(1);
+        let bob = test_keypair(2);
+        let charlie = test_keypair(3);
+        let alice_fvk = FullViewingKey::from_keypair(&alice);
+        let bob_fvk = FullViewingKey::from_keypair(&bob);
+        let charlie_fvk = FullViewingKey::from_keypair(&charlie);
+
+        let encrypted = crate::ecies::encrypt(
+            b"secret",
+            bob_fvk.ivk_public(),
+            b"ctx",
+            alice_fvk.ovk(),
+        )
+        .unwrap();
+
+        let result = charlie_fvk.decrypt_outgoing(
+            &encrypted, bob_fvk.ivk_public(), b"ctx",
+        );
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "ecies")]
+    #[test]
+    fn tampered_ovk_blob_fails() {
+        let alice = test_keypair(1);
+        let bob = test_keypair(2);
+        let alice_fvk = FullViewingKey::from_keypair(&alice);
+        let bob_fvk = FullViewingKey::from_keypair(&bob);
+
+        let mut encrypted = crate::ecies::encrypt(
+            b"tamper test",
+            bob_fvk.ivk_public(),
+            b"ctx",
+            alice_fvk.ovk(),
+        )
+        .unwrap();
+
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 0x01;
+
+        // IVK still works
+        assert!(bob_fvk.decrypt_incoming(&encrypted, b"ctx").is_ok());
+        // OVK fails
+        assert!(alice_fvk.decrypt_outgoing(
+            &encrypted, bob_fvk.ivk_public(), b"ctx",
+        ).is_err());
+    }
+}

--- a/src/viewing_key.rs
+++ b/src/viewing_key.rs
@@ -4,9 +4,6 @@
 // Copyright (c) 2019 Web 3 Foundation
 // See LICENSE for licensing information.
 //
-// Authors:
-// - Jeff Burdges <jeff@web3.foundation>
-
 //! ## Full viewing keys for sr25519
 //!
 //! A Penumbra-style viewing key hierarchy that separates


### PR DESCRIPTION
## Summary
- Adds ECIES (Elliptic Curve Integrated Encryption Scheme) over Ristretto255
- Uses ChaCha20-Poly1305 for authenticated encryption and Merlin transcripts for key derivation
- New `ecies` feature flag with `encrypt` / `decrypt` public API
- Wire format: `[version: 1B] [ephemeral_pk: 32B] [nonce: 12B] [ciphertext + tag: N+16B]` (61 bytes overhead)

## Test plan
- [x] Unit tests: round-trip, deterministic encryption, empty plaintext, wrong context, truncated ciphertext, bad version, tampered ciphertext, large plaintext
- [ ] Review by maintainers